### PR TITLE
change RELEASE_URLBASE to the Unofficial Builds server

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -10,6 +10,7 @@ image_tag_pfx=unofficial-build-recipe-
 # 'fetch-source' is a special case and needs to go first
 recipes=" \
   fetch-source \
+  headers \
   x86 \
   musl \
   armv6l \
@@ -28,6 +29,9 @@ fullversion="$1"
 . ${__dirname}/_decode_version.sh
 decode "$fullversion"
 # see _decode_version for all of the magic variables now set and available for use
+
+# Point RELEASE_URLBASE to the Unofficial Builds server
+unofficial_release_urlbase="https://unofficial-builds.nodejs.org/download/${disttype}/"
 
 thislogdir="${logdir}/$(date -u +'%Y%m%d%H%M')-${fullversion}"
 mkdir -p $thislogdir
@@ -68,7 +72,7 @@ for recipe in $recipes; do
   docker run --rm \
     ${ccachemount} ${sourcemount} ${stagingmount} \
     "${image_tag_pfx}${recipe}" \
-    "$release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url" \
+    "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url" \
     > ${thislogdir}/${recipe}.log 2>&1
 done
 

--- a/recipes/headers/Dockerfile
+++ b/recipes/headers/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.9
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node
+
+RUN apk add --no-cache bash gnupg curl
+
+RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/master/keys/node.keys) \
+  ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done
+
+COPY --chown=node:node run.sh /home/node/run.sh
+
+VOLUME /home/node/.ccache
+VOLUME /out
+VOLUME /home/node/node.tar.xz
+
+USER node
+
+ENTRYPOINT [ "/home/node/run.sh" ]

--- a/recipes/headers/run.sh
+++ b/recipes/headers/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+release_urlbase="$1"
+disttype="$2"
+customtag="$3"
+datestring="$4"
+commit="$5"
+fullversion="$6"
+source_url="$7"
+config_flags=
+
+cd /home/node
+
+gpg_keys=$(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/master/keys/node.keys)
+
+for key in ${gpg_keys}; do
+  gpg --list-keys "$key" ||
+  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ||
+  gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" ||
+  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ;
+done
+
+curl -fsSLO --compressed "${source_url}/../node-${fullversion}-headers.tar.gz"
+curl -fsSLO --compressed "${source_url}/../node-${fullversion}-headers.tar.xz"
+
+if [[ "$disttype" = "release" ]]; then
+  curl -fsSLO --compressed "${source_url}/../SHASUMS256.txt.asc"
+  gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+  grep " node-${fullversion}-headers.tar.*\$" SHASUMS256.txt | sha256sum -c -
+fi
+
+mv node-${fullversion}-headers.tar* /out/


### PR DESCRIPTION
This adds a recipe that downloads a copy of the headers to be included in the Unofficial Builds releases and changes the RELEASE_URLBASE to point to that copy.

The node-gyp changes in https://github.com/nodejs/node-gyp/pull/1875 require this. Windows ARM64 releases need to download `node.lib` from this server. Changing node-gyp to get `node.lib` from here and the headers from the main server doesn't make much sense to me. This approach makes it more consistent, at the expense of having to duplicate the headers files.

@rvagg can you take a look? I haven't tested this. I plan to land this, let docker update and then fix anything that needs fixing. But I can test the changes in the server and update this PR if you prefer. In any case, I'll run the new recipe for v12.8.0 which I'm using to test the node-gyp side.

