### PR TITLE
Add -y flag to add-apt-repository

### DIFF
--- a/recipes/armv6l/Dockerfile
+++ b/recipes/armv6l/Dockerfile
@@ -6,7 +6,7 @@ RUN addgroup --gid 1000 node \
 RUN apt-get update \
     && apt-get dist-upgrade -y \
     && apt-get install -y software-properties-common \
-    && add-apt-repository ppa:ubuntu-toolchain-r/test \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     &&  apt-get update \
     && apt-get install -y \
          git \


### PR DESCRIPTION
Adding '-y' prevents the following prompt from blocking Docker's progress.
```
 More info: https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test                                                                                                                   
Press [ENTER] to continue or ctrl-c to cancel adding it  
```