### PR TITLE
fix: python2 is just python on xenial

### DIFF
--- a/recipes/armv6l/Dockerfile
+++ b/recipes/armv6l/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
          gcc-6-multilib \
          g++-6-multilib \
          make \
-         python2 \
+         python \
          python3 \
          ccache \
          xz-utils


### PR DESCRIPTION
Ref: https://github.com/nodejs/unofficial-builds/pull/29