### PR TITLE
fixup armv6l recipes

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -13,6 +13,7 @@ recipes=" \
   x86 \
   musl \
   armv6l \
+  armv6l-pre16 \
   x64-pointer-compression \
   x64-usdt \
 "

--- a/recipes/armv6l/Dockerfile
+++ b/recipes/armv6l/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
          g++-8-multilib \
          make \
          python3 \
+	 python3-distutils \
          ccache \
          xz-utils
 


### PR DESCRIPTION
Add the renamed `armv6l-pre16` recipe to the explicit recipe list to build.

Add missing dependency (`python3-distutils`) for the new `armv6l` recipe to fix 
```
ModuleNotFoundError: No module named 'distutils.spawn'
```
error. FWIW in https://github.com/nodejs/build/blob/master/ansible/roles/docker/templates/ubuntu1804_arm_cross.Dockerfile.j2 `python3-distutils` is installed as a dependency of `python3-pip` -- we do not need to install pip on the unofficial build Docker image as we're not running tap2junit here.

Refs: https://github.com/nodejs/unofficial-builds/pull/33