### PR TITLE
chore: Use openpgp/ubuntu keyservers

### DIFF
--- a/recipes/fetch-source/Dockerfile
+++ b/recipes/fetch-source/Dockerfile
@@ -7,9 +7,8 @@ RUN apk add --no-cache bash gnupg curl
 
 RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/master/keys/node.keys) \
   ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
   done
 
 COPY --chown=node:node run.sh /home/node/run.sh

--- a/recipes/fetch-source/run.sh
+++ b/recipes/fetch-source/run.sh
@@ -18,9 +18,8 @@ gpg_keys=$(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/master/
 
 for key in ${gpg_keys}; do
   gpg --list-keys "$key" ||
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ||
-  gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" ||
-  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ;
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
 done
 
 curl -fsSLO --compressed "$source_url"

--- a/recipes/headers/Dockerfile
+++ b/recipes/headers/Dockerfile
@@ -7,9 +7,8 @@ RUN apk add --no-cache bash gnupg curl
 
 RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/master/keys/node.keys) \
   ; do \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
   done
 
 COPY --chown=node:node run.sh /home/node/run.sh

--- a/recipes/headers/run.sh
+++ b/recipes/headers/run.sh
@@ -17,9 +17,8 @@ gpg_keys=$(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/master/
 
 for key in ${gpg_keys}; do
   gpg --list-keys "$key" ||
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ||
-  gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" ||
-  gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ;
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
 done
 
 curl -fsSLO --compressed "${source_url}/../node-${fullversion}-headers.tar.gz"


### PR DESCRIPTION
SKS no longer publishes DNS. Same approach from docker-node
Fixes https://github.com/nodejs/unofficial-builds/issues/37