### PR TITLE
Allow setting user and group ID

### DIFF
--- a/bin/prepare-images.sh
+++ b/bin/prepare-images.sh
@@ -6,7 +6,7 @@ __dirname="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 image_tag_pfx=unofficial-build-recipe-
 
 for recipe in $(ls ${__dirname}/../recipes/); do
-	docker build ${__dirname}/../recipes/${recipe}/ -t ${image_tag_pfx}${recipe}
+	docker build ${__dirname}/../recipes/${recipe}/ -t ${image_tag_pfx}${recipe} --build-arg UID=1000 --build-arg GID=1000
 done
 
 docker system prune -f

--- a/recipes/armv6l-pre16/Dockerfile
+++ b/recipes/armv6l-pre16/Dockerfile
@@ -1,7 +1,10 @@
 FROM ubuntu:16.04
 
-RUN addgroup --gid 1000 node \
-    && adduser --gid 1000 --uid 1000 --disabled-password --gecos node node
+ARG GID=1000
+ARG UID=1000
+
+RUN addgroup --gid $GID node \
+    && adduser --gid $GID --uid $UID --disabled-password --gecos node node
 
 RUN apt-get update \
     && apt-get dist-upgrade -y \

--- a/recipes/armv6l/Dockerfile
+++ b/recipes/armv6l/Dockerfile
@@ -1,7 +1,10 @@
 FROM ubuntu:18.04
 
-RUN addgroup --gid 1000 node \
-    && adduser --gid 1000 --uid 1000 --disabled-password --gecos node node
+ARG GID=1000
+ARG UID=1000
+
+RUN addgroup --gid $GID node \
+    && adduser --gid $GID --uid $UID --disabled-password --gecos node node
 
 RUN apt-get update \
     && apt-get dist-upgrade -y \

--- a/recipes/fetch-source/Dockerfile
+++ b/recipes/fetch-source/Dockerfile
@@ -1,7 +1,10 @@
 FROM alpine:3.9
 
-RUN addgroup -g 1000 node \
-    && adduser -u 1000 -G node -s /bin/sh -D node
+ARG GID=1000
+ARG UID=1000
+
+RUN addgroup -g $GID node \
+    && adduser -u $UID -G node -s /bin/sh -D node
 
 RUN apk add --no-cache bash gnupg curl
 

--- a/recipes/headers/Dockerfile
+++ b/recipes/headers/Dockerfile
@@ -1,7 +1,10 @@
 FROM alpine:3.9
 
-RUN addgroup -g 1000 node \
-    && adduser -u 1000 -G node -s /bin/sh -D node
+ARG GID=1000
+ARG UID=1000
+
+RUN addgroup -g $GID node \
+    && adduser -u $UID -G node -s /bin/sh -D node
 
 RUN apk add --no-cache bash gnupg curl
 

--- a/recipes/musl/Dockerfile
+++ b/recipes/musl/Dockerfile
@@ -1,7 +1,10 @@
 FROM alpine:3.9
 
-RUN addgroup -g 1000 node \
-    && adduser -u 1000 -G node -s /bin/sh -D node
+ARG GID=1000
+ARG UID=1000
+
+RUN addgroup -g $GID node \
+    && adduser -u $UID -G node -s /bin/sh -D node
 
 RUN apk add --no-cache \
         libstdc++ \

--- a/recipes/x64-pointer-compression/Dockerfile
+++ b/recipes/x64-pointer-compression/Dockerfile
@@ -1,7 +1,10 @@
 FROM centos:7
 
-RUN groupadd --gid 1000 node \
-    && adduser --gid 1000 --uid 1000 node
+ARG GID=1000
+ARG UID=1000
+
+RUN groupadd --gid $GID node \
+    && adduser --gid $GID --uid $UID node
 
 COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
 

--- a/recipes/x64-usdt/Dockerfile
+++ b/recipes/x64-usdt/Dockerfile
@@ -1,7 +1,10 @@
 FROM centos:7
 
-RUN groupadd --gid 1000 node \
-    && adduser --gid 1000 --uid 1000 node
+ARG GID=1000
+ARG UID=1000
+
+RUN groupadd --gid $GID node \
+    && adduser --gid $GID --uid $UID node
 
 COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
 

--- a/recipes/x86/Dockerfile
+++ b/recipes/x86/Dockerfile
@@ -1,7 +1,10 @@
 FROM centos:7
 
-RUN groupadd --gid 1000 node \
-    && adduser --gid 1000 --uid 1000 node
+ARG GID=1000
+ARG UID=1000
+
+RUN groupadd --gid $GID node \
+    && adduser --gid $GID --uid $UID node
 
 COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
 


### PR DESCRIPTION
Allow the user ID and group IDs to be changed when preparing the images for running/testing on systems where the host is running under a user with a user ID other than 1000.

I'm testing out some changes and the system I'm using is shared so my user id is not 1000. This PR allows me to only have to modify one place (`bin/prepare-images.sh`) to change the user id so I can successfully mount the shared directories from the host.