### PR TITLE
Update compiler for Node.js 16

### DIFF
--- a/recipes/x64-pointer-compression/Dockerfile
+++ b/recipes/x64-pointer-compression/Dockerfile
@@ -16,6 +16,7 @@ RUN yum install -y epel-release \
          ccache \
          xz-utils \
          devtoolset-8 \
+         devtoolset-9 \
          glibc-devel
 
 COPY --chown=node:node run.sh /home/node/run.sh

--- a/recipes/x64-pointer-compression/cloudlinux.repo
+++ b/recipes/x64-pointer-compression/cloudlinux.repo
@@ -2,3 +2,8 @@
 name=Cloudlinux devtoolset-8
 baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-8/x86_64/
 gpgcheck=0
+
+[cloudlinux-sclo-devtoolset-9]
+name=Cloudlinux devtoolset-9
+baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/
+gpgcheck=0

--- a/recipes/x64-pointer-compression/run.sh
+++ b/recipes/x64-pointer-compression/run.sh
@@ -19,8 +19,13 @@ cd "node-${fullversion}"
 
 export CC="ccache gcc"
 export CXX="ccache g++"
+export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
-. /opt/rh/devtoolset-8/enable
+if [ $MAJOR_VERSION -ge 16 ]; then
+  . /opt/rh/devtoolset-9/enable
+else
+  . /opt/rh/devtoolset-8/enable
+fi
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="x64" \

--- a/recipes/x64-usdt/Dockerfile
+++ b/recipes/x64-usdt/Dockerfile
@@ -17,6 +17,8 @@ RUN yum install -y epel-release \
          xz-utils \
          devtoolset-8 \
          devtoolset-8-systemtap-sdt-devel \
+         devtoolset-9 \
+         devtoolset-9-systemtap-sdt-devel \
          glibc-devel
 
 COPY --chown=node:node run.sh /home/node/run.sh

--- a/recipes/x64-usdt/cloudlinux.repo
+++ b/recipes/x64-usdt/cloudlinux.repo
@@ -2,3 +2,8 @@
 name=Cloudlinux devtoolset-8
 baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-8/x86_64/
 gpgcheck=0
+
+[cloudlinux-sclo-devtoolset-9]
+name=Cloudlinux devtoolset-9
+baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/
+gpgcheck=0

--- a/recipes/x64-usdt/run.sh
+++ b/recipes/x64-usdt/run.sh
@@ -19,8 +19,13 @@ cd "node-${fullversion}"
 
 export CC="ccache gcc"
 export CXX="ccache g++"
+export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
-. /opt/rh/devtoolset-8/enable
+if [ $MAJOR_VERSION -ge 16 ]; then
+  . /opt/rh/devtoolset-9/enable
+else
+  . /opt/rh/devtoolset-8/enable
+fi
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="x64" \

--- a/recipes/x86/Dockerfile
+++ b/recipes/x86/Dockerfile
@@ -16,6 +16,7 @@ RUN yum install -y epel-release \
          ccache \
          xz-utils \
          devtoolset-6.i686 \
+         devtoolset-9.i686 \
          glibc-devel.i686
 
 COPY --chown=node:node run.sh /home/node/run.sh

--- a/recipes/x86/cloudlinux.repo
+++ b/recipes/x86/cloudlinux.repo
@@ -2,3 +2,8 @@
 name=Cloudlinux devtoolset-6
 baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-6/i386/
 gpgcheck=0
+
+[cloudlinux-sclo-devtoolset-9]
+name=Cloudlinux devtoolset-9
+baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/i386/
+gpgcheck=0

--- a/recipes/x86/run.sh
+++ b/recipes/x86/run.sh
@@ -21,8 +21,13 @@ export CC="ccache gcc"
 export CXX="ccache g++"
 export CXXFLAGS=-m32
 export CFLAGS=-m32
+export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
-. /opt/rh/devtoolset-6/enable
+if [ $MAJOR_VERSION -ge 16 ]; then
+  . /opt/rh/devtoolset-9/enable
+else
+  . /opt/rh/devtoolset-6/enable
+fi
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="x86" \


### PR DESCRIPTION
Node.js 16 requires gcc/g++ 8.3 or later.

V8 9.2 included in Node.js 16.6.0 fails to compile with gcc/g++ 8.2.1:
https://unofficial-builds.nodejs.org/logs/202107292303-v16.6.0/x64-usdt.log

<details>

```
../deps/v8/src/builtins/builtins-call-gen.cc: In instantiation of 'void v8::internal::CallOrConstructBuiltinsAssembler::CallReceiver(v8::internal::Builtins::Name, v8::internal::TNode<v8::internal::Int32T>, v8::internal::TNode<v8::internal::UintPtrT>, v8::base::Optional<v8::internal::TNode<v8::internal::Object> >) [with Descriptor = v8::internal::CallTrampoline_BaselineDescriptor]':
../deps/v8/src/builtins/builtins-call-gen.cc:81:42:   required from here
../deps/v8/src/builtins/builtins-call-gen.cc:491:14: error: passing 'const v8::base::Optional<v8::internal::TNode<v8::internal::Object> >' as 'this' argument discards qualifiers [-fpermissive]
       return *maybe_receiver;
              ^~~~~~~~~~~~~~~
In file included from ../deps/v8/src/compiler/code-assembler.h:17,
                 from ../deps/v8/src/codegen/code-stub-assembler.h:15,
                 from ../deps/v8/src/builtins/builtins-call-gen.h:8,
                 from ../deps/v8/src/builtins/builtins-call-gen.cc:5:
../deps/v8/src/base/optional.h:575:16: note:   in call to 'constexpr T& v8::base::Optional<T>::operator*() & [with T = v8::internal::TNode<v8::internal::Object>]'
   constexpr T& operator*() & {
                ^~~~~~~~
../deps/v8/src/builtins/builtins-call-gen.cc: In instantiation of 'void v8::internal::CallOrConstructBuiltinsAssembler::CallReceiver(v8::internal::Builtins::Name, v8::internal::TNode<v8::internal::Int32T>, v8::internal::TNode<v8::internal::UintPtrT>, v8::base::Optional<v8::internal::TNode<v8::internal::Object> >) [with Descriptor = v8::internal::CallTrampoline_Baseline_CompactDescriptor]':
../deps/v8/src/builtins/builtins-call-gen.cc:479:3:   required from 'void v8::internal::CallOrConstructBuiltinsAssembler::CallReceiver(v8::internal::Builtins::Name, v8::base::Optional<v8::internal::TNode<v8::internal::Object> >) [with Descriptor = v8::internal::CallTrampoline_Baseline_CompactDescriptor]'
../deps/v8/src/builtins/builtins-call-gen.cc:72:79:   required from here
../deps/v8/src/builtins/builtins-call-gen.cc:491:14: error: passing 'const v8::base::Optional<v8::internal::TNode<v8::internal::Object> >' as 'this' argument discards qualifiers [-fpermissive]
       return *maybe_receiver;
              ^~~~~~~~~~~~~~~
In file included from ../deps/v8/src/compiler/code-assembler.h:17,
                 from ../deps/v8/src/codegen/code-stub-assembler.h:15,
                 from ../deps/v8/src/builtins/builtins-call-gen.h:8,
                 from ../deps/v8/src/builtins/builtins-call-gen.cc:5:
../deps/v8/src/base/optional.h:575:16: note:   in call to 'constexpr T& v8::base::Optional<T>::operator*() & [with T = v8::internal::TNode<v8::internal::Object>]'
   constexpr T& operator*() & {
                ^~~~~~~~
In file included from /opt/rh/devtoolset-8/root/usr/include/c++/8/functional:59,
                 from ../deps/v8/src/codegen/code-stub-assembler.h:8,
                 from ../deps/v8/src/builtins/builtins-call-gen.h:8,
                 from ../deps/v8/src/builtins/builtins-call-gen.cc:5:
/opt/rh/devtoolset-8/root/usr/include/c++/8/bits/std_function.h:666:7: error: 'std::function<_Res(_ArgTypes ...)>::function(_Functor) [with _Functor = v8::internal::CallOrConstructBuiltinsAssembler::CallReceiver(v8::internal::Builtins::Name, v8::internal::TNode<v8::internal::Int32T>, v8::internal::TNode<v8::internal::UintPtrT>, v8::base::Optional<v8::internal::TNode<v8::internal::Object> >) [with Descriptor = v8::internal::CallTrampoline_BaselineDescriptor]::<lambda()>; <template-parameter-2-2> = void; <template-parameter-2-3> = void; _Res = v8::internal::TNode<v8::internal::Object>; _ArgTypes = {}]', declared using local type 'v8::internal::CallOrConstructBuiltinsAssembler::CallReceiver(v8::internal::Builtins::Name, v8::internal::TNode<v8::internal::Int32T>, v8::internal::TNode<v8::internal::UintPtrT>, v8::base::Optional<v8::internal::TNode<v8::internal::Object> >) [with Descriptor = v8::internal::CallTrampoline_BaselineDescriptor]::<lambda()>', is used but never defined [-fpermissive]
       function<_Res(_ArgTypes...)>::
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/rh/devtoolset-8/root/usr/include/c++/8/bits/std_function.h:666:7: error: 'std::function<_Res(_ArgTypes ...)>::function(_Functor) [with _Functor = v8::internal::CallOrConstructBuiltinsAssembler::CallReceiver(v8::internal::Builtins::Name, v8::internal::TNode<v8::internal::Int32T>, v8::internal::TNode<v8::internal::UintPtrT>, v8::base::Optional<v8::internal::TNode<v8::internal::Object> >) [with Descriptor = v8::internal::CallTrampoline_Baseline_CompactDescriptor]::<lambda()>; <template-parameter-2-2> = void; <template-parameter-2-3> = void; _Res = v8::internal::TNode<v8::internal::Object>; _ArgTypes = {}]', declared using local type 'v8::internal::CallOrConstructBuiltinsAssembler::CallReceiver(v8::internal::Builtins::Name, v8::internal::TNode<v8::internal::Int32T>, v8::internal::TNode<v8::internal::UintPtrT>, v8::base::Optional<v8::internal::TNode<v8::internal::Object> >) [with Descriptor = v8::internal::CallTrampoline_Baseline_CompactDescriptor]::<lambda()>', is used but never defined [-fpermissive]
make[2]: *** [tools/v8_gypfiles/v8_initializers.target.mk:388: /home/node/node-v16.6.0/out/Release/obj.target/v8_initializers/deps/v8/src/builtins/builtins-call-gen.o] Error 1
```
</details>

The baseline compiler requirement for Node.js 16 is gcc/g++ 8.3: https://github.com/nodejs/node/blob/v16.0.0/BUILDING.md#supported-toolchains

This PR updates the compiler used for Node.js 16 and later by enabling `devtoolset-9`.

The Cloud Linux repo's `devtoolset-8` package is gcc/g++ 8.2.1:
https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-8/x86_64/
![image](https://user-images.githubusercontent.com/5445507/129374968-cb7ee527-d038-44f6-9788-33d1562403df.png)

FWIW Software Collections does have a `devtoolset-8` that provides gcc/g++ 8.3.1 but only for x64:
http://mirror.centos.org/centos/7/sclo/x86_64/rh/Packages/d/
![image](https://user-images.githubusercontent.com/5445507/129375471-36dde287-71b2-4d68-b64d-4fb24fa49f61.png)

Pointer compression builds were separately broken in 16.4.0 https://github.com/nodejs/TSC/issues/790#issuecomment-893457655 and may need https://github.com/nodejs/node/pull/39664 (not yet in a release).