### PR TITLE
chore: update Apline versions

### DIFF
--- a/recipes/fetch-source/Dockerfile
+++ b/recipes/fetch-source/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:latest
 
 ARG GID=1000
 ARG UID=1000
@@ -8,7 +8,7 @@ RUN addgroup -g $GID node \
 
 RUN apk add --no-cache bash gnupg curl
 
-RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/master/keys/node.keys) \
+RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/HEAD/keys/node.keys) \
   ; do \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \

--- a/recipes/fetch-source/run.sh
+++ b/recipes/fetch-source/run.sh
@@ -14,7 +14,7 @@ config_flags=
 
 cd /home/node
 
-gpg_keys=$(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/master/keys/node.keys)
+gpg_keys=$(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/HEAD/keys/node.keys)
 
 for key in ${gpg_keys}; do
   gpg --list-keys "$key" ||

--- a/recipes/headers/Dockerfile
+++ b/recipes/headers/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:latest
 
 ARG GID=1000
 ARG UID=1000
@@ -8,7 +8,7 @@ RUN addgroup -g $GID node \
 
 RUN apk add --no-cache bash gnupg curl
 
-RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/master/keys/node.keys) \
+RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/HEAD/keys/node.keys) \
   ; do \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \

--- a/recipes/headers/run.sh
+++ b/recipes/headers/run.sh
@@ -13,7 +13,7 @@ config_flags=
 
 cd /home/node
 
-gpg_keys=$(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/master/keys/node.keys)
+gpg_keys=$(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/HEAD/keys/node.keys)
 
 for key in ${gpg_keys}; do
   gpg --list-keys "$key" ||

--- a/recipes/musl/Dockerfile
+++ b/recipes/musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.15
 
 ARG GID=1000
 ARG UID=1000


### PR DESCRIPTION
Since 3.9 hit EOL last year, I figure I'd update the base https://alpinelinux.org/releases/. Alternate would be just to bump to 3.12, since it's the oldest supported version

- Use latest alpine for headers/fetch jobs
- Update docker-node keys for branch rename
- use latest Alpine for Musl builder image