### PR TITLE
Remove unused yum repo from x64-glibc-217 recipe

### DIFF
--- a/recipes/x64-glibc-217/cloudlinux.repo
+++ b/recipes/x64-glibc-217/cloudlinux.repo
@@ -1,8 +1,3 @@
-[cloudlinux-sclo-devtoolset-8]
-name=Cloudlinux devtoolset-8
-baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-8/x86_64/
-gpgcheck=0
-
 [cloudlinux-sclo-devtoolset-9]
 name=Cloudlinux devtoolset-9
 baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/


### PR DESCRIPTION
The `x64-glibc-217` recipe is only built for Node.js 18+ and hence `devtoolset-8` is not needed here (only needed for versions <16)