### PR TITLE
Remove custom yum repo in favor for centos-release-scl-rh

### DIFF
--- a/recipes/x64-glibc-217/Dockerfile
+++ b/recipes/x64-glibc-217/Dockerfile
@@ -6,9 +6,8 @@ ARG UID=1000
 RUN groupadd --gid $GID node \
     && adduser --gid $GID --uid $UID node
 
-COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
-
 RUN yum install -y epel-release \
+    && yum install -y centos-release-scl-rh \
     && yum upgrade -y \
     && yum install -y \
          git \

--- a/recipes/x64-glibc-217/Dockerfile
+++ b/recipes/x64-glibc-217/Dockerfile
@@ -6,7 +6,8 @@ ARG UID=1000
 RUN groupadd --gid $GID node \
     && adduser --gid $GID --uid $UID node
 
-RUN yum install -y epel-release \
+RUN ulimit -n 1024 \
+    && yum install -y epel-release \
     && yum install -y centos-release-scl-rh \
     && yum upgrade -y \
     && yum install -y \

--- a/recipes/x64-glibc-217/cloudlinux.repo
+++ b/recipes/x64-glibc-217/cloudlinux.repo
@@ -1,4 +1,0 @@
-[cloudlinux-sclo-devtoolset-9]
-name=Cloudlinux devtoolset-9
-baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/
-gpgcheck=0


### PR DESCRIPTION
This PR should make the `x64-glibc-217` recipe a little simpler by removing the custom yum repo used to install `devtoolset-9`. Instead we can get `devtoolset-9` from installing `centos-release-scl-rh`.

I've also added a `ulimit -n 1024` before running `yum` because of this known issue on centos 7: https://stackoverflow.com/questions/74345206/centos-7-docker-yum-installation-gets-stuck

I haven't personally run into this bug on centos 7, but it seems to be a good idea to add it to make the install more stable.