### PR TITLE
fix: retry fetch-source curl request

### DIFF
--- a/recipes/fetch-source/run.sh
+++ b/recipes/fetch-source/run.sh
@@ -22,7 +22,15 @@ for key in ${gpg_keys}; do
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
 done
 
-curl -fsSLO --compressed "$source_url"
+# Curl with retry
+for ((i=1;i<=7;i++)); do
+  if curl -fsSLO --compressed "$source_url"; then
+    break
+  else
+    echo "Curl failed with status $?. Retrying in 10 seconds..."
+    sleep 10
+  fi
+done
 
 if [[ "$disttype" = "release" ]]; then
   curl -fsSLO --compressed "${source_url}/../SHASUMS256.txt.asc"


### PR DESCRIPTION
This PR is in response to the fetch-source script failing on multiple occasions in the past. https://github.com/nodejs/unofficial-builds/issues/87, https://github.com/nodejs/unofficial-builds/issues/81, https://github.com/nodejs/unofficial-builds/issues/86

If the request fails, the curl command is repeated a total of 6 times (10 second sleep time), which equates to a minute total wait time. I think that should be enough time for any potential cache issues to resolve.