### PR TITLE
Add recipe definition for building on loong64

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This list of officially supported platforms is available in the Node.js [BUILDIN
  * **linux-x86**: Linux x86 (32-bit) binaries compiled against libc 2.17, similar to the way the official [linux-x64 binaries are produced](https://github.com/nodejs/node/blob/master/BUILDING.md#official-binary-platforms-and-toolchains). 32-bit Linux binaries were dropped for Node.js 10 and 32-bit support is now considered "Experimental".
  * **linux-armv6l**: Linux ARMv6 binaries, cross-compiled on Ubuntu 16.04 with a [custom GCC 6 toolchain](https://github.com/rvagg/rpi-newer-crosstools) (for Node.js versions earlier than 16) or Ubuntu 18.04 with a [custom GCC 8 toolchain](https://github.com/rvagg/rpi-newer-crosstools) (for Node.js 16 and later) in a similar manner to the official linux-armv7l binaries. Binaries are optimized for `armv6zk` which is suitable for Raspberry Pi devices (1, 1+ and Zero in particular). ARMv6 binaries were dropped from Node.js 12 and ARMv6 support is now considered "Experimental".
  * **riscv64**: Linux riscv64 (RISC-V), cross compiled on Ubuntu 20.04 with the toolchain which the Adoptium project uses (for  now...). Built with --openssl-no-asm (Should be with --with-intl=none but that gets overriden)
+ * **loong64**: Linux loong64 (LoongArch64), cross compiled on Ubuntu 20.04 with the toolchain.
 
 "Experimental" status for Node.js is defined as:
 > Experimental: May not compile or test suite may not pass. The core team does not create releases for these platforms. Test failures on experimental platforms do not block releases. Contributions to improve support for these platforms are welcome.
@@ -67,6 +68,7 @@ unofficial-builds is maintained by:
 * [@rvagg](https://github.com/rvagg)
 * [@richardlau](https://github.com/richardlau)
 * [@sxa](https://github.com/sxa)
+* [@shipujin](https://github.com/shipujin)
 * ... _contribute something and add yourself here!_
 
 ## Emeritus

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -18,6 +18,7 @@ recipes=" \
   x64-pointer-compression \
   x64-usdt \
   riscv64 \
+  loong64 \
 "
 ccachedir=$(realpath "${workdir}/.ccache")
 stagingdir=$(realpath "${workdir}/staging")

--- a/recipes/loong64/Dockerfile
+++ b/recipes/loong64/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04
+
+ARG GID=1000
+ARG UID=1000
+
+RUN addgroup --gid $GID node \
+    && adduser --gid $GID --uid $UID --disabled-password --gecos node node
+
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
+    && apt-get install -y \
+         git \
+	 g++-13 \
+         curl \
+         make \
+         python3 \
+	 python3-distutils \
+         ccache \
+         xz-utils
+
+RUN curl https://github.com/loongson/build-tools/releases/download/2022.09.06/loongarch64-clfs-7.3-cross-tools-gcc-glibc.tar.xz | tar xJf - -C /opt
+
+COPY --chown=node:node run.sh /home/node/run.sh
+
+VOLUME /home/node/.ccache
+VOLUME /out
+VOLUME /home/node/node.tar.xz
+
+USER node
+
+ENTRYPOINT [ "/home/node/run.sh" ]

--- a/recipes/loong64/run.sh
+++ b/recipes/loong64/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+release_urlbase="$1"
+disttype="$2"
+customtag="$3"
+datestring="$4"
+commit="$5"
+fullversion="$6"
+source_url="$7"
+config_flags="--openssl-no-asm"
+
+cd /home/node
+
+tar -xf node.tar.xz
+cd "node-${fullversion}"
+
+export CC_host="ccache gcc-13"
+export CXX_host="ccache g++-13"
+export CC="ccache /opt/cross-tools/bin/loongarch64-unknown-linux-gnu-gcc"
+export CXX="ccache /opt/cross-tools/bin/loongarch64-unknown-linux-gnu-g++"
+
+make -j$(getconf _NPROCESSORS_ONLN) binary V= \
+  DESTCPU="loong64" \
+  ARCH="loong64" \
+  VARIATION="" \
+  DISTTYPE="$disttype" \
+  CUSTOMTAG="$customtag" \
+  DATESTRING="$datestring" \
+  COMMIT="$commit" \
+  RELEASE_URLBASE="$release_urlbase" \
+  CONFIG_FLAGS="$config_flags"
+
+mv node-*.tar.?z /out/

--- a/recipes/loong64/should-build.sh
+++ b/recipes/loong64/should-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+__dirname=$1
+fullversion=$2
+
+. ${__dirname}/_decode_version.sh
+
+decode "$fullversion"
+
+test "$major" -ge "20"


### PR DESCRIPTION
Configuration to allow building for LoongArch as an unofficial build platform.

Since this is my first contribution to here and I don't have access to the box used for cross-compilation I cannot verify for certain that it will work properly, but the setup seems adequate for building the latest versions for LoongArcch.

(If there are problems with the "loong64 nodejs" build, please let me know, thank you very much)

Cheers~
