### PR TITLE
loong64: v18.x branch supports loong64 builds from v18.18.0 

### DIFF
--- a/recipes/loong64/should-build.sh
+++ b/recipes/loong64/should-build.sh
@@ -7,4 +7,4 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "20"
+test "$major" -ge "18"


### PR DESCRIPTION
loong64: The v18.x branch supports loong64 builds from v18.18.0 (--openssl-no-asm)

The loong64 platform "--openssl-no-asm" supports patch:
https://github.com/nodejs/node/commit/f4617a4f81
https://github.com/nodejs/node/commit/3be53358bc
