### PR TITLE
feat: add local_build.sh script and instructions for local/dev use

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 _**This project is experimental: its output is not guaranteed to remain consistent and its existence is not guaranteed into the future.** This project is in need of a community of maintainers to keep it viable. If you would like to join, please submit pull requests to improve the work here._
 
+* [About](#about)
+* [Builds](#builds)
+* [How](#how)
+* [How to add new target](#how-to-add-new-target)
+* [Manual build triggers](#manual-build-triggers)
+* [Local use](#local-use)
+  * [Setup for local builds](#setup-for-local-builds)
+  * [Building](#building)
+* [Team](#team)
+* [Emeritus](#emeritus)
+
+
+## About
+
 The **unofficial-builds** project aims to provide Node.js binaries for some platforms not made available officially by the Node.js project at nodejs.org. Node.js is used on a large variety of platforms, but the Node.js project, in consultation with the [Node.js Build Working Group](https://github.com/nodejs/build), maintains a limited set of platforms that it tests code on and produces binaries for.
 
 This list of officially supported platforms is available in the Node.js [BUILDING.md](https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list), where you can also find details in the [official nodejs.org binaries](https://github.com/nodejs/node/blob/main/BUILDING.md#official-binary-platforms-and-toolchains) section. Some platforms are "supported" in that they are tested by the Node.js test infrastructure, but they don't have binaries produced for nodejs.org. Other platforms receive minimal or no official support.
@@ -67,6 +81,42 @@ unofficial-builds/bin/queue-push.sh v16.4.0 # queue a new build for "v16.4.0" - 
 This places "v16.4.0" into `~/var/build_queue` which will be read on the next invocation of the build check timer. It may take up to 5 minutes for the build to start, at which point the log should be visible at <https://unofficial-builds.nodejs.org/logs/>.
 
 The same process can be used to queue `rc` or `test` builds.
+
+## Local use
+
+This repository is primarily intended for use on the unofficial-builds server but it can be used locally for testing purposes. The `bin/local_build.sh` script is designed to mirror the server build process but with local trigger and for one specific recipe at a time.
+
+### Setup for local builds
+
+On deploy, this repository is placed within a the `unofficial-builds` home directory on the server, it is intended to operate from a subdirectory of where the assets are build, it's `$workdir` is the parent directory of wherever it is located. The `local_build.sh` script will create some directories within its `$workdir` so it's best to create a new directory for it to operate in. e.g.:
+
+* `$workdir`
+  * unofficial-builds/ *(this repository)*
+  * staging/src/ *(source files for builds, made by `local_build.sh`)*
+  * staging/`$disttype`/`$version`/ *(staging directory for builds, made by `local_build.sh`)*
+  * .ccache/ *(ccache cache directory to speed up repeat builds, made by `local_build.sh`)*
+
+e.g. clone this repository using the following commands to place it within an `unofficial-builds-home` directory:
+
+```sh
+mkdir unofficial-builds-home
+cd unofficial-builds-home
+git clone https://github.com/nodejs/unofficial-builds
+```
+
+However, you can override the default `$workdir` behaviour with a `-w <newdir>` argument to `local_build.sh` and direct it to a different directory where it can create its own subdirectories, so the above layout is not strictly necessary.
+
+Please note that these scripts and recipes are intended to run in a Linux x64 environment, they may not work on other platforms, YMMV.
+
+### Building
+
+Once you have cloned this repository, you can build a specific recipe by running `bin/local_build.sh` with the recipe (an existing one or one you create within the `recipes/` subdirectory) name and the Node.js version you want to build. e.g.
+
+```sh
+bin/local_build.sh musl v21.0.0 # build musl binaries for Node.js v21.0.0
+```
+
+A successful build will place the source in `$workdir/staging/src/` and binaries in `$workdir/staging/release/v21.0.0/`.
 
 ## Team
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Please note that these scripts and recipes are intended to run in a Linux x64 en
 Once you have cloned this repository, you can build a specific recipe by running `bin/local_build.sh` with the recipe (an existing one or one you create within the `recipes/` subdirectory) name and the Node.js version you want to build. e.g.
 
 ```sh
-bin/local_build.sh musl v21.0.0 # build musl binaries for Node.js v21.0.0
+bin/local_build.sh -r musl -v v21.0.0 # build musl binaries for Node.js v21.0.0
 ```
 
 A successful build will place the source in `$workdir/staging/src/` and binaries in `$workdir/staging/release/v21.0.0/`.

--- a/bin/local_build.sh
+++ b/bin/local_build.sh
@@ -1,0 +1,106 @@
+#!/bin/bash -e
+
+usage_exit() {
+  echo "Usage: $0 -r <recipe> -v <version> [-w <workdir>]"
+  exit 1
+}
+
+## -- SETUP -- ##
+
+__dirname="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# by default, workdir is the parent directory of the cloned repo
+workdir=${workdir:-"$__dirname"/../..}
+image_tag_pfx=unofficial-build-recipe-
+recipe=""
+fullversion=""
+
+# parse command line options
+while getopts ":w:r:v:" opt; do
+  case ${opt} in
+    w )
+      workdir=$OPTARG
+      ;;
+    r )
+      recipe=$OPTARG
+      ;;
+    v )
+      fullversion=$OPTARG
+      ;;
+    \? )
+      echo "Invalid option: $OPTARG" 1>&2
+      usage_exit
+      ;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument" 1>&2
+      usage_exit
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+if [[ -z "$recipe" ]]; then
+  echo "Please supply a recipe name from the recipes directory"
+  usage_exit
+fi
+if [[ -z "$fullversion" ]]; then
+  echo "Please supply a Node.js version string"
+  usage_exit
+fi
+
+# check that the recipe exists and has a Dockerfile
+if [[ ! -d "${__dirname}/../recipes/${recipe}" ]]; then
+  echo "Recipe ${recipe} does not exist"
+  usage_exit
+fi
+if [[ ! -f "${__dirname}/../recipes/${recipe}/Dockerfile" ]]; then
+  echo "Recipe ${recipe} does not have a Dockerfile"
+  usage_exit
+fi
+
+. ${__dirname}/_decode_version.sh
+decode "$fullversion"
+
+workdir=$(realpath "${workdir}")
+stagingdir="${workdir}/staging"
+ccachedir="${workdir}/.ccache"
+sourcedir="${stagingdir}/src/${fullversion}"
+mkdir -p $sourcedir
+sourcefile="${sourcedir}/node-${fullversion}.tar.xz"
+stagingoutdir="${stagingdir}/${disttype_promote}/${fullversion}"
+mkdir -p $stagingoutdir
+mkdir -p $ccachedir
+
+unofficial_release_urlbase="https://unofficial-builds.nodejs.org/download/${disttype}/"
+
+## -- BUILD IMAGES -- ##
+
+for r in "fetch-source" "${recipe}"; do
+  echo "Building ${r} recipe and tagging as ${image_tag_pfx}${r}..."
+  docker build ${__dirname}/../recipes/${r}/ -t ${image_tag_pfx}${r} --build-arg UID=1000 --build-arg GID=1000
+done
+
+## -- DOWNLOAD SOURCE -- ##
+
+if [[ ! -f "${sourcefile}" ]]; then
+  echo "Downloading source tarball..."
+  docker run --rm \
+    -v ${sourcedir}:/out \
+    "${image_tag_pfx}fetch-source" \
+    "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url"
+  echo "Done, source tarball is at ${sourcefile}"
+else
+  echo "Source tarball already exists at ${sourcefile}, skipping download"
+fi
+
+## -- RUN BUILD -- ##
+
+echo "Building ${recipe} recipe..."
+sourcemount="-v ${sourcefile}:/home/node/node.tar.xz"
+stagingmount="-v ${stagingoutdir}:/out"
+ccachemount="-v ${ccachedir}/${recipe}/:/home/node/.ccache/"
+mkdir -p "${ccachedir}/${recipe}"
+docker run --rm \
+  ${ccachemount} ${sourcemount} ${stagingmount} \
+  "${image_tag_pfx}${recipe}" \
+  "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url"
+echo "Successful build should result in assets in ${stagingoutdir}"

--- a/bin/local_build.sh
+++ b/bin/local_build.sh
@@ -74,9 +74,22 @@ unofficial_release_urlbase="https://unofficial-builds.nodejs.org/download/${dist
 
 ## -- BUILD IMAGES -- ##
 
+UID=$(id -u)
+GID=$(id -g)
+# there's a good chance of a UID/GID conflict in the container if we are less
+# than 1000, so bump to 1000 if that's the case.
+if [[ $UID -lt 1000 ]]; then
+  UID=1000
+  echo -e "\e[1mWarning: UID is less than 1000, setting to 1000, output files will be owned by this UID\e[0m"
+fi
+if [[ $GID -lt 1000 ]]; then
+  GID=1000
+  echo -e "\e[1mWarning: GID is less than 1000, setting to 1000\e[0m"
+fi
+
 for r in "fetch-source" "${recipe}"; do
   echo "Building ${r} recipe and tagging as ${image_tag_pfx}${r}..."
-  docker build ${__dirname}/../recipes/${r}/ -t ${image_tag_pfx}${r} --build-arg UID=$(id -u) --build-arg GID=$(id -g)
+  docker build ${__dirname}/../recipes/${r}/ -t ${image_tag_pfx}${r} --build-arg UID=${UID} --build-arg GID=${GID}
 done
 
 ## -- DOWNLOAD SOURCE -- ##

--- a/bin/local_build.sh
+++ b/bin/local_build.sh
@@ -76,7 +76,7 @@ unofficial_release_urlbase="https://unofficial-builds.nodejs.org/download/${dist
 
 for r in "fetch-source" "${recipe}"; do
   echo "Building ${r} recipe and tagging as ${image_tag_pfx}${r}..."
-  docker build ${__dirname}/../recipes/${r}/ -t ${image_tag_pfx}${r} --build-arg UID=1000 --build-arg GID=1000
+  docker build ${__dirname}/../recipes/${r}/ -t ${image_tag_pfx}${r} --build-arg UID=$(id -u) --build-arg GID=$(id -g)
 done
 
 ## -- DOWNLOAD SOURCE -- ##
@@ -84,6 +84,7 @@ done
 if [[ ! -f "${sourcefile}" ]]; then
   echo "Downloading source tarball..."
   docker run --rm \
+    --user=$(id -u) \
     -v ${sourcedir}:/out \
     "${image_tag_pfx}fetch-source" \
     "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url"
@@ -100,6 +101,7 @@ stagingmount="-v ${stagingoutdir}:/out"
 ccachemount="-v ${ccachedir}/${recipe}/:/home/node/.ccache/"
 mkdir -p "${ccachedir}/${recipe}"
 docker run --rm \
+  --user=$(id -u) \
   ${ccachemount} ${sourcemount} ${stagingmount} \
   "${image_tag_pfx}${recipe}" \
   "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url"

--- a/bin/local_build.sh
+++ b/bin/local_build.sh
@@ -74,22 +74,22 @@ unofficial_release_urlbase="https://unofficial-builds.nodejs.org/download/${dist
 
 ## -- BUILD IMAGES -- ##
 
-UID=$(id -u)
-GID=$(id -g)
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
 # there's a good chance of a UID/GID conflict in the container if we are less
 # than 1000, so bump to 1000 if that's the case.
-if [[ $UID -lt 1000 ]]; then
-  UID=1000
+if [[ $USER_ID -lt 1000 ]]; then
+  USER_ID=1000
   echo -e "\e[1mWarning: UID is less than 1000, setting to 1000, output files will be owned by this UID\e[0m"
 fi
-if [[ $GID -lt 1000 ]]; then
-  GID=1000
+if [[ $GROUP_ID -lt 1000 ]]; then
+  GROUP_ID=1000
   echo -e "\e[1mWarning: GID is less than 1000, setting to 1000\e[0m"
 fi
 
 for r in "fetch-source" "${recipe}"; do
   echo "Building ${r} recipe and tagging as ${image_tag_pfx}${r}..."
-  docker build ${__dirname}/../recipes/${r}/ -t ${image_tag_pfx}${r} --build-arg UID=${UID} --build-arg GID=${GID}
+  docker build ${__dirname}/../recipes/${r}/ -t ${image_tag_pfx}${r} --build-arg UID=${USER_ID} --build-arg GID=${GROUP_ID}
 done
 
 ## -- DOWNLOAD SOURCE -- ##

--- a/bin/local_build.sh
+++ b/bin/local_build.sh
@@ -97,7 +97,7 @@ done
 if [[ ! -f "${sourcefile}" ]]; then
   echo "Downloading source tarball..."
   docker run --rm \
-    --user=$(id -u) \
+    --user=${USER_ID} \
     -v ${sourcedir}:/out \
     "${image_tag_pfx}fetch-source" \
     "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url"
@@ -114,7 +114,7 @@ stagingmount="-v ${stagingoutdir}:/out"
 ccachemount="-v ${ccachedir}/${recipe}/:/home/node/.ccache/"
 mkdir -p "${ccachedir}/${recipe}"
 docker run --rm \
-  --user=$(id -u) \
+  --user=${USER_ID} \
   ${ccachemount} ${sourcemount} ${stagingmount} \
   "${image_tag_pfx}${recipe}" \
   "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url"

--- a/recipes/fetch-source/Dockerfile
+++ b/recipes/fetch-source/Dockerfile
@@ -8,16 +8,16 @@ RUN addgroup -g $GID node \
 
 RUN apk add --no-cache bash gnupg curl
 
-RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/HEAD/keys/node.keys) \
-  ; do \
-      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
-      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
-  done
-
 COPY --chown=node:node run.sh /home/node/run.sh
 
 VOLUME /out/
 
 USER node
+
+RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/HEAD/keys/node.keys) \
+  ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done
 
 ENTRYPOINT [ "/home/node/run.sh" ]


### PR DESCRIPTION
About time this got done, mainly useful for people contributing new recipes, so they can actually test them locally (and we can too).