### PR TITLE
Don't fetch gpg keys in fetch-source Dockerfile

### DIFF
--- a/recipes/fetch-source/Dockerfile
+++ b/recipes/fetch-source/Dockerfile
@@ -14,10 +14,4 @@ VOLUME /out/
 
 USER node
 
-RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/HEAD/keys/node.keys) \
-  ; do \
-      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
-      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
-  done
-
 ENTRYPOINT [ "/home/node/run.sh" ]


### PR DESCRIPTION
fetch-source's run.sh already fetches the gpg keys, and doing it in both places can lead to hangs due to permissions