### PR TITLE
fix: create ~/.gnupg prior to invoking gnupg

### DIFF
--- a/recipes/fetch-source/Dockerfile
+++ b/recipes/fetch-source/Dockerfile
@@ -14,7 +14,9 @@ VOLUME /out/
 
 USER node
 
-RUN for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/HEAD/keys/node.keys) \
+RUN mkdir ~/.gnupg && \
+    chmod 700 ~/.gnupg && \
+    for key in $(curl -sL https://raw.githubusercontent.com/nodejs/docker-node/HEAD/keys/node.keys) \
   ; do \
       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \


### PR DESCRIPTION
addresses a problem where gnupg creates a lockfile in the directory which causes problems when trying to invoke it later on during a run of fetch-source

Ref: https://github.com/nodejs/unofficial-builds/pull/109
Closes: https://github.com/nodejs/unofficial-builds/pull/109