### PR TITLE
feat: add explicit versioning for nodejs-dist-indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ The build process can be described as:
 ## How to add new target
 
 1. Add target dir in recipe, and ensure that the necessary functions are implemented according to the above process description.
-2. Add target to the recipes list in bin/build.sh.
-3. In order for the index.dat and index.json to index the new target, you may need to modify [nodejs-dist-indexer](https://github.com/nodejs/nodejs-dist-indexer/blob/main/transform-filename.js).
-4. Add or modify the README if necessary.
+2. Add target to the recipes list in `bin/_config.sh`.
+3. In order for the `index.dat` and `index.json` to index the new target, you will likely need to modify [nodejs-dist-indexer](https://github.com/nodejs/nodejs-dist-indexer/blob/main/transform-filename.js) so it understands the new filenames.
+4. After a nodejs-dist-indexer release, the new version will need to be listed in `bin/_config.sh`.
+5. Add or modify the README if necessary.
 
 ## Manual build triggers
 

--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -1,0 +1,20 @@
+# All of our build recipes, new recipes should be added here.
+recipes=" \
+  headers \
+  x86 \
+  musl \
+  armv6l \
+  x64-debug \
+  x64-glibc-217 \
+  x64-pointer-compression \
+  x64-usdt \
+  riscv64 \
+  loong64 \
+"
+
+# This should be updated as new versions of nodejs-dist-indexer are released to
+# include new assets published here; this is not done automatically for security
+# reasons.
+dist_indexer_version=v1.7.1
+
+image_tag_pfx=unofficial-build-recipe-

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -2,24 +2,13 @@
 
 # The heart of the build process: given a valid Node.js version string,
 # fetch the source file then build each type of asset using a pre-built
-# docker image
+# docker image.
 
 __dirname="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 workdir=${workdir:-"$__dirname"/../..}
-image_tag_pfx=unofficial-build-recipe-
-# all of our build recipes, new recipes just go into this list,
-recipes=" \
-  headers \
-  x86 \
-  musl \
-  armv6l \
-  x64-debug \
-  x64-glibc-217 \
-  x64-pointer-compression \
-  x64-usdt \
-  riscv64 \
-  loong64 \
-"
+
+source "${__dirname}/_config.sh"
+
 ccachedir=$(realpath "${workdir}/.ccache")
 stagingdir=$(realpath "${workdir}/staging")
 distdir=$(realpath "${workdir}/download")
@@ -99,7 +88,7 @@ mv ${stagingoutdir}/node-v* ${distoutdir}
 (cd "${distoutdir}" && shasum -a256 $(ls node* 2> /dev/null) > SHASUMS256.txt) || exit 1
 echo "Generating indexes (this may error if there is no upstream tag for this build)"
 # index.json and index.tab
-npx nodejs-dist-indexer --dist ${distdir_promote} --indexjson ${distdir_promote}/index.json  --indextab ${distdir_promote}/index.tab || true
+npm exec -y nodejs-dist-indexer@${dist_indexer_version} -- --dist ${distdir_promote} --indexjson ${distdir_promote}/index.json  --indextab ${distdir_promote}/index.tab || true
 
 echo "Finished build @ $(date)"
 

--- a/bin/local_build.sh
+++ b/bin/local_build.sh
@@ -10,7 +10,9 @@ usage_exit() {
 __dirname="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # by default, workdir is the parent directory of the cloned repo
 workdir=${workdir:-"$__dirname"/../..}
-image_tag_pfx=unofficial-build-recipe-
+
+source "${__dirname}/_config.sh"
+
 recipe=""
 fullversion=""
 

--- a/bin/prepare-images.sh
+++ b/bin/prepare-images.sh
@@ -3,7 +3,8 @@
 # Rebuild recipe images, any directory in ../recipes gets a build
 
 __dirname="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-image_tag_pfx=unofficial-build-recipe-
+
+source "${__dirname}/_config.sh"
 
 for recipe in $(ls ${__dirname}/../recipes/); do
 	docker build ${__dirname}/../recipes/${recipe}/ -t ${image_tag_pfx}${recipe} --build-arg UID=1000 --build-arg GID=1000


### PR DESCRIPTION
I'm doing a bit of a security balancing act here. I've enabled auto-releases on https://github.com/nodejs/nodejs-dist-indexer, because it's just so much simpler and more efficient to get changes shipped. _But_ we use `npx` to run it here, so while it's easier to get releases out, it opens a novel vector for getting privileged(-enough) access on the unofficial-builds server to mess with binaries.

So this change puts the burden on the person adding a new recipe to get dist-indexer updated and put the new version number into the config here.