### PR TITLE
chore: update Alpine to 3.18

### DIFF
--- a/recipes/musl/Dockerfile
+++ b/recipes/musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.18
 
 ARG GID=1000
 ARG UID=1000


### PR DESCRIPTION
- Still supported
- Used by the official Node.js Docker images

Closes: https://github.com/nodejs/unofficial-builds/issues/103
