### PR TITLE
Update run.sh to exclude sys/random.h for this target

### DIFF
--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -19,6 +19,7 @@ tar -xf node.tar.xz
 # configuring cares correctly to not use sys/random.h on this target
 cd "node-${fullversion}"/deps/cares/config/linux
 sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./ares_config.h
+sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./ares_config.h
 
 cd /home/node
 

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -15,6 +15,13 @@ config_flags=""
 cd /home/node
 
 tar -xf node.tar.xz
+
+# configuring cares correctly to not use sys/random.h on this target
+cd "node-${fullversion}"/deps/cares/config/linux
+sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./ares_config.h
+
+cd /home/node
+
 cd "node-${fullversion}"
 
 export CC="ccache gcc"


### PR DESCRIPTION
nodejs sources were updated with some glibc 2.25+ functionality around expecting/detecting sys/random.h and getrandom()
This target specifically is meant for lesser glibc versions, thus we specifically disable the new expectations