### PR TITLE
Adding SYS_RANDOM and GET_RANDOM fixes to x86, x64-pointer-compression, armv6l

### DIFF
--- a/recipes/armv6l/run.sh
+++ b/recipes/armv6l/run.sh
@@ -15,6 +15,14 @@ config_flags=
 cd /home/node
 
 tar -xf node.tar.xz
+
+# configuring cares correctly to not use sys/random.h on this target
+cd "node-${fullversion}"/deps/cares/config/linux
+sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./ares_config.h
+sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./ares_config.h
+
+cd /home/node
+
 cd "node-${fullversion}"
 
 export CC_host="ccache gcc-8 -m32"

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -19,6 +19,7 @@ tar -xf node.tar.xz
 # configuring cares correctly to not use sys/random.h on this target
 cd "node-${fullversion}"/deps/cares/config/linux
 sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./ares_config.h
+sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./ares_config.h
 
 cd /home/node
 

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -15,6 +15,13 @@ config_flags=""
 cd /home/node
 
 tar -xf node.tar.xz
+
+# configuring cares correctly to not use sys/random.h on this target
+cd "node-${fullversion}"/deps/cares/config/linux
+sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./ares_config.h
+
+cd /home/node
+
 cd "node-${fullversion}"
 
 export CC="ccache gcc"

--- a/recipes/x64-pointer-compression/run.sh
+++ b/recipes/x64-pointer-compression/run.sh
@@ -15,6 +15,14 @@ config_flags=--experimental-enable-pointer-compression
 cd /home/node
 
 tar -xf node.tar.xz
+
+# configuring cares correctly to not use sys/random.h on this target
+cd "node-${fullversion}"/deps/cares/config/linux
+sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./ares_config.h
+sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./ares_config.h
+
+cd /home/node
+
 cd "node-${fullversion}"
 
 export CC="ccache gcc"

--- a/recipes/x86/run.sh
+++ b/recipes/x86/run.sh
@@ -15,6 +15,14 @@ config_flags=--openssl-no-asm
 cd /home/node
 
 tar -xf node.tar.xz
+
+# configuring cares correctly to not use sys/random.h on this target
+cd "node-${fullversion}"/deps/cares/config/linux
+sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./ares_config.h
+sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./ares_config.h
+
+cd /home/node
+
 cd "node-${fullversion}"
 
 export CC="ccache gcc"


### PR DESCRIPTION
Builds succeed:

❯  ls -al ~/src/github/staging/release/v20.12.1|grep -v musl|grep -v xz
total 695032
drwxr-xr-x  12 scosol  staff       384 Apr  5 12:35 .
drwxr-xr-x   4 scosol  staff       128 Apr  3 11:31 ..
-rw-------@  1 scosol  staff  43014257 Apr  5 12:35 node-v20.12.1-linux-armv6l.tar.gz
-rw-------@  1 scosol  staff  46947672 Apr  3 12:48 node-v20.12.1-linux-x64-glibc-217.tar.gz
-rw-------@  1 scosol  staff  47016182 Apr  4 12:28 node-v20.12.1-linux-x64-pointer-compression.tar.gz
-rw-------@  1 scosol  staff  45960624 Apr  4 21:58 node-v20.12.1-linux-x86.tar.gz