### PR TITLE
fix: unquote wildcard for staging file move

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -130,7 +130,7 @@ for recipe in "${recipes_to_build[@]}"; do
   # to finish before consumers can use the assets
   #
   # promote all assets in staging
-  mv "${stagingoutdir}/node-v*" "$distoutdir"
+  mv "${stagingoutdir}"/node-v* "${distoutdir}"
   # generate SHASUM256.txt
   (cd "$distoutdir" && shasum -a256 $(ls node* 2> /dev/null) > SHASUMS256.txt) || exit 1
   echo "Generating indexes (this may error if there is no upstream tag for this build)"


### PR DESCRIPTION
another overzealous quote that is avoiding wildcard expansion leading to this error:

```
+ mv '/home/nodejs/staging/release/v20.12.0/node-v*' /home/nodejs/download/release/v20.12.0
mv: cannot stat '/home/nodejs/staging/release/v20.12.0/node-v*': No such file or directory
```

in https://unofficial-builds.nodejs.org/logs/202404060140-v20.12.0/build.log

even though the files are there

/cc @matthewkeil 