### PR TITLE
Adding no-build logic for x64-usdt target if node version > 18

### DIFF
--- a/recipes/x64-usdt/run.sh
+++ b/recipes/x64-usdt/run.sh
@@ -21,6 +21,11 @@ export CC="ccache gcc"
 export CXX="ccache g++"
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
+if [ $MAJOR_VERSION -ge 19 ]; then
+  echo 'dtrace support was removed in nodejs v19+ ... exiting'
+  exit 0
+fi
+
 if [ $MAJOR_VERSION -ge 16 ]; then
   . /opt/rh/devtoolset-9/enable
 fi

--- a/recipes/x64-usdt/run.sh
+++ b/recipes/x64-usdt/run.sh
@@ -21,11 +21,6 @@ export CC="ccache gcc"
 export CXX="ccache g++"
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
-if [ $MAJOR_VERSION -ge 19 ]; then
-  echo 'dtrace support was removed in nodejs v19+ ... exiting'
-  exit 0
-fi
-
 if [ $MAJOR_VERSION -ge 16 ]; then
   . /opt/rh/devtoolset-9/enable
 fi

--- a/recipes/x64-usdt/should-build.sh
+++ b/recipes/x64-usdt/should-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+__dirname=$1
+fullversion=$2
+
+. ${__dirname}/_decode_version.sh
+
+decode "$fullversion"
+
+test "$major" -le "18"


### PR DESCRIPTION
Node19+ removed dtrace support, thus there is no point/ability to build this target for these versions.