### PR TITLE
fix: move debug build to last since it's failing atm

### DIFF
--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -4,12 +4,12 @@ recipes=(
   "x86"
   "musl"
   "armv6l"
-  "x64-debug"
   "x64-glibc-217"
   "x64-pointer-compression"
   "x64-usdt"
   "riscv64"
   "loong64"
+  "x64-debug"
 )
 
 


### PR DESCRIPTION
Ref: https://github.com/nodejs/unofficial-builds/issues/138

haven't figured out why this is demanding so much space yet, but it might need a resize of the root device which I'm not looking forward to pulling off, either that or putting docker var onto a separate device