### PR TITLE
Adding instantiation of local var/build_queue

### DIFF
--- a/bin/local_build.sh
+++ b/bin/local_build.sh
@@ -13,8 +13,8 @@ __dirname="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 workdir="${workdir:-"${__dirname}/../.."}"
 
 # setup needed directories and build queue file to match prod server
-mkdir -p "${__dirname}../../../var"
-touch "${__dirname}../../../var/build_queue"
+mkdir -p "${__dirname}/../../var"
+touch "${__dirname}/../../var/build_queue"
 
 # include needed config
 source "${__dirname}/_config.sh"

--- a/bin/local_build.sh
+++ b/bin/local_build.sh
@@ -8,12 +8,17 @@ usage_exit() {
 ## -- SETUP -- ##
 
 __dirname="$(CDPATH= cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${__dirname}/_config.sh"
-source "${__dirname}/_decode_version.sh"
 
 # by default, workdir is the parent directory of the cloned repo
 workdir="${workdir:-"${__dirname}/../.."}"
 
+# setup needed directories and build queue file to match prod server
+mkdir -p "${__dirname}../../../var"
+touch "${__dirname}../../../var/build_queue"
+
+# include needed config
+source "${__dirname}/_config.sh"
+source "${__dirname}/_decode_version.sh"
 
 recipe=""
 fullversion=""


### PR DESCRIPTION
For a fresh local build, the script expects the build queue to be in a location matching its location on the PROD server (relative to the bin dir), which doesn't exist unless created by the user.

Instead, we will create this structure in the local_build.sh file so that the script works immediately.