### PR TITLE
Disable x86 builds for version 22 and higher

### DIFF
--- a/recipes/x86/should-build.sh
+++ b/recipes/x86/should-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+__dirname=$1
+fullversion=$2
+
+. ${__dirname}/_decode_version.sh
+
+decode "$fullversion"
+
+test "$major" -lt "22"


### PR DESCRIPTION
x86 is no longer supported and x86 builds fail in version 22. Disabling the build to prevent a the failing buikld to abort other recipes.