### PR TITLE
ci: Disable armv6l on Node 22+

### DIFF
--- a/recipes/armv6l/should-build.sh
+++ b/recipes/armv6l/should-build.sh
@@ -7,4 +7,5 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "16"
+# TODO: Re-enable if a compatible compiler can be found
+test "$major" -lt "22"


### PR DESCRIPTION
Since Node 16 isn't supported anyway, I swapped the check to match #142 

v22 errors can be seen in https://unofficial-builds.nodejs.org/logs/202404242143-v22.0.0/armv6l.log in case someone wants to try and fix it later