### PR TITLE
chore: update Alpine to 3.19

### DIFF
--- a/recipes/musl/Dockerfile
+++ b/recipes/musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.19
 
 ARG GID=1000
 ARG UID=1000


### PR DESCRIPTION
This is necessary to compile V8 with C++20 support.

Refs: https://github.com/nodejs/node/pull/45427