### PR TITLE
Add custom yup repo in favor of centos-release-scl-rh

### DIFF
--- a/recipes/x64-glibc-217/Dockerfile
+++ b/recipes/x64-glibc-217/Dockerfile
@@ -6,9 +6,10 @@ ARG UID=1000
 RUN groupadd --gid $GID node \
     && adduser --gid $GID --uid $UID node
 
+COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
+
 RUN ulimit -n 1024 \
     && yum install -y epel-release \
-    && yum install -y centos-release-scl-rh \
     && yum upgrade -y \
     && yum install -y \
          git \

--- a/recipes/x64-glibc-217/cloudlinux.repo
+++ b/recipes/x64-glibc-217/cloudlinux.repo
@@ -1,0 +1,4 @@
+[cloudlinux-sclo-devtoolset-9]
+name=Cloudlinux devtoolset-9
+baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/
+gpgcheck=0


### PR DESCRIPTION
This PR is kindly reverting what was done at https://github.com/nodejs/unofficial-builds/pull/85 

CentOS7 went EOL last week and this approach is causing errors related with the package mirror . `centos-release-scl-rh` is also gone from the vault so I think it's a good idea to revert this change for now.
 
\cc @rvagg @richardlau 