### PR TITLE
fix: Do not use mirrorlist for centos:7 builds.

### DIFF
--- a/recipes/x64-glibc-217/Dockerfile
+++ b/recipes/x64-glibc-217/Dockerfile
@@ -7,8 +7,12 @@ RUN groupadd --gid $GID node \
     && adduser --gid $GID --uid $UID node
 
 RUN ulimit -n 1024 \
+    && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     && yum install -y epel-release \
     && yum install -y centos-release-scl-rh \
+    && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
     && yum upgrade -y \
     && yum install -y \
          git \

--- a/recipes/x64-pointer-compression/Dockerfile
+++ b/recipes/x64-pointer-compression/Dockerfile
@@ -8,7 +8,9 @@ RUN groupadd --gid $GID node \
 
 COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
 
-RUN yum install -y epel-release \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && yum install -y epel-release \
     && yum upgrade -y \
     && yum install -y \
          git \

--- a/recipes/x64-usdt/Dockerfile
+++ b/recipes/x64-usdt/Dockerfile
@@ -8,7 +8,9 @@ RUN groupadd --gid $GID node \
 
 COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
 
-RUN yum install -y epel-release \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && yum install -y epel-release \
     && yum upgrade -y \
     && yum install -y \
          git \

--- a/recipes/x86/Dockerfile
+++ b/recipes/x86/Dockerfile
@@ -8,7 +8,9 @@ RUN groupadd --gid $GID node \
 
 COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
 
-RUN yum install -y epel-release \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && yum install -y epel-release \
     && yum upgrade -y \
     && yum install -y \
          git \


### PR DESCRIPTION
Fixes #147.

All the centos:7 builds are failing because [the mirrorlist for centos repos has removed CentOS 7](https://support.cpanel.net/hc/en-us/articles/24571139547415-Could-not-retrieve-mirrorlist-http-mirrorlist-centos-org-on-CentOS-7).  This fixes this by modifying the yum repo config files so we fetch repos from valut.centos.org instead of from the mirrorlist URLs.

Tried this out with `x64-glibc-217` and made sure it built successfully.  I also tried `x64-pointer-compression` and stopped it before it completed, but made sure it got into the compilation phase (it won't get anywhere near that far without this fix).
