### PR TITLE
fix: x64-glibc-217 build failed for v22.7.0

### DIFF
--- a/recipes/x64-glibc-217/Dockerfile
+++ b/recipes/x64-glibc-217/Dockerfile
@@ -6,6 +6,14 @@ ARG UID=1000
 RUN groupadd --gid $GID node \
     && adduser --gid $GID --uid $UID node
 
+RUN cat <<EOF | tee -a /etc/yum.repos.d/devtoolset-12.repo
+[devtoolset-12]
+name=Devtoolset 12
+baseurl=https://buildlogs.centos.org/c7-devtoolset-12.x86_64/
+enabled=1
+gpgcheck=0
+EOF
+
 RUN ulimit -n 1024 \
     && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
@@ -22,7 +30,7 @@ RUN ulimit -n 1024 \
          rh-python38 \
          ccache \
          xz-utils \
-         devtoolset-11 \
+         devtoolset-12 \
          glibc-devel
 
 COPY --chown=node:node run.sh /home/node/run.sh

--- a/recipes/x64-glibc-217/Dockerfile
+++ b/recipes/x64-glibc-217/Dockerfile
@@ -22,7 +22,7 @@ RUN ulimit -n 1024 \
          rh-python38 \
          ccache \
          xz-utils \
-         devtoolset-9 \
+         devtoolset-11 \
          glibc-devel
 
 COPY --chown=node:node run.sh /home/node/run.sh

--- a/recipes/x64-glibc-217/Dockerfile
+++ b/recipes/x64-glibc-217/Dockerfile
@@ -19,7 +19,7 @@ RUN ulimit -n 1024 \
          curl \
          make \
          python2 \
-         python3 \
+         rh-python38 \
          ccache \
          xz-utils \
          devtoolset-9 \

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -34,7 +34,7 @@ export CC="ccache gcc"
 export CXX="ccache g++"
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
-. /opt/rh/devtoolset-11/enable
+. /opt/rh/devtoolset-12/enable
 . /opt/rh/rh-python38/enable
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -17,9 +17,14 @@ cd /home/node
 tar -xf node.tar.xz
 
 # configuring cares correctly to not use sys/random.h on this target
-cd "node-${fullversion}"/deps/cares/config/linux
-sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./ares_config.h
-sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./ares_config.h
+cd "node-${fullversion}"/deps/cares
+sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./config/linux/ares_config.h
+sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./config/linux/ares_config.h
+
+# fix https://github.com/c-ares/c-ares/issues/850
+if [[ "$(grep -o 'ARES_VERSION_STR "[^"]*"' ./include/ares_version.h | awk '{print $2}' | tr -d '"')" == "1.33.0" ]]; then
+  sed -i 's/MSG_FASTOPEN/TCP_FASTOPEN_CONNECT/g' ./src/lib/ares__socket.c
+fi
 
 cd /home/node
 
@@ -29,7 +34,8 @@ export CC="ccache gcc"
 export CXX="ccache g++"
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
-. /opt/rh/devtoolset-9/enable
+. /opt/rh/devtoolset-11/enable
+. /opt/rh/rh-python38/enable
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="x64" \


### PR DESCRIPTION
1. Upgrade GCC version to 12 and Python version to 3.8
2. Backport the patch from https://github.com/c-ares/c-ares/issues/850