### PR TITLE
fix: remove python2 from musl build

### DIFF
--- a/recipes/musl/Dockerfile
+++ b/recipes/musl/Dockerfile
@@ -18,7 +18,6 @@ RUN apk add --no-cache \
         libgcc \
         linux-headers \
         make \
-        python2 \
         python3 \
         ccache \
         xz


### PR DESCRIPTION
not available in alpine:3.19, failing to build

nothing new is being deployed because this is failing: https://unofficial-builds.nodejs.org/logs/github-webhook.log