### PR TITLE
Riscv64 native

### DIFF
--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -8,6 +8,7 @@ recipes=(
   "x64-pointer-compression"
   "x64-usdt"
   "riscv64"
+  "riscv64-native"
   "loong64"
   "x64-debug"
 )

--- a/recipes/riscv64-native/Dockerfile
+++ b/recipes/riscv64-native/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:20.04
+
+ARG GID=1000
+ARG UID=1000
+
+RUN addgroup --gid $GID node \
+    && adduser --gid $GID --uid $UID --disabled-password --gecos node node
+
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
+    && apt-get install -y \
+         git \
+	 g++-9 \
+         curl \
+         make \
+         python3 \
+	 python3-distutils \
+         ccache \
+         xz-utils \
+         build-essential
+
+COPY --chown=node:node run.sh /home/node/run.sh
+
+VOLUME /home/node/.ccache
+VOLUME /out
+VOLUME /home/node/node.tar.xz
+
+USER node
+
+ENTRYPOINT [ "/home/node/run.sh" ]

--- a/recipes/riscv64-native/run.sh
+++ b/recipes/riscv64-native/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+release_urlbase="$1"
+disttype="$2"
+customtag="$3"
+datestring="$4"
+commit="$5"
+fullversion="$6"
+source_url="$7"
+config_flags="--openssl-no-asm"
+
+cd /home/node
+
+tar -xf node.tar.xz
+cd "node-${fullversion}"
+
+export CC="ccache"
+export CXX="ccache"
+
+make -j$(getconf _NPROCESSORS_ONLN) binary V= \
+  DESTCPU="riscv64" \
+  ARCH="riscv64" \
+  VARIATION="" \
+  DISTTYPE="$disttype" \
+  CUSTOMTAG="$customtag" \
+  DATESTRING="$datestring" \
+  COMMIT="$commit" \
+  RELEASE_URLBASE="$release_urlbase" \
+  CONFIG_FLAGS="$config_flags"
+
+# If removal of ICU is desired, add "BUILD_INTL_FLAGS=--with-intl=none" above
+
+mv node-*.tar.?z /out/

--- a/recipes/riscv64-native/should-build.sh
+++ b/recipes/riscv64-native/should-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+__dirname=$1
+fullversion=$2
+
+. ${__dirname}/_decode_version.sh
+
+decode "$fullversion"
+
+test "$major" -ge "17" && test "$major" -lt "22"


### PR DESCRIPTION
riscv64 hardware is getting larger (64-core and 192-core hardware are available), so this is a recipe to build in riscv64 hardware without the use of cross compiler or distro-external toolchains.

Tested with:
bin/local_build.sh -r riscv64-native -v v20.18.0