### PR TITLE
fix: use resolved URLs to download release assets

### DIFF
--- a/bin/_decode_version.sh
+++ b/bin/_decode_version.sh
@@ -42,7 +42,8 @@ decode() {
     fi
 
     release_urlbase="https://nodejs.org/download/${disttype}/"
-    source_url="${release_urlbase}${fullversion}/node-${fullversion}.tar.xz"
+    source_urlbase="${release_urlbase}${fullversion}"
+    source_url="${source_urlbase}/node-${fullversion}.tar.xz"
     # this is just an unfortunate artifact of history, most disttypes that are not nightly or release
     # go through "custom" but pop out the other end in special directories, see Node's Makefile and
     # the www dist "promote" scripts in nodejs/build
@@ -79,6 +80,7 @@ if [ ! -z ${TEST+x} ]; then
   assert_eq "" "$datestring"
   assert_eq "" "$commit"
   assert_eq "https://nodejs.org/download/release/" "$release_urlbase"
+  assert_eq "https://nodejs.org/download/release/v11.12.0" "$source_urlbase"
   assert_eq "https://nodejs.org/download/release/v11.12.0/node-v11.12.0.tar.xz" "$source_url"
 
   decode "v10.9.0-nightly20171102d4471e06e8"
@@ -89,6 +91,7 @@ if [ ! -z ${TEST+x} ]; then
   assert_eq "20171102" "$datestring"
   assert_eq "d4471e06e8" "$commit"
   assert_eq "https://nodejs.org/download/nightly/" "$release_urlbase"
+  assert_eq "https://nodejs.org/download/nightly/v10.9.0-nightly20171102d4471e06e8" "$source_urlbase"
   assert_eq "https://nodejs.org/download/nightly/v10.9.0-nightly20171102d4471e06e8/node-v10.9.0-nightly20171102d4471e06e8.tar.xz" "$source_url"
 
   decode "v12.0.0-nightly201904208d901bb44e"
@@ -115,6 +118,7 @@ if [ ! -z ${TEST+x} ]; then
   assert_eq "" "$datestring"
   assert_eq "" "$commit"
   assert_eq "https://nodejs.org/download/rc/" "$release_urlbase"
+  assert_eq "https://nodejs.org/download/rc/v10.0.0-rc.0" "$source_urlbase"
   assert_eq "https://nodejs.org/download/rc/v10.0.0-rc.0/node-v10.0.0-rc.0.tar.xz" "$source_url"
 
   decode "v6.12.0-rc.4"
@@ -132,6 +136,7 @@ if [ ! -z ${TEST+x} ]; then
   assert_eq "" "$datestring"
   assert_eq "" "$commit"
   assert_eq "https://nodejs.org/download/rc/" "$release_urlbase"
+  assert_eq "https://nodejs.org/download/rc/v12.0.0-rc.2" "$source_urlbase"
   assert_eq "https://nodejs.org/download/rc/v12.0.0-rc.2/node-v12.0.0-rc.2.tar.xz" "$source_url"
 
   decode "v12.0.1-test201904152fed83dee8"
@@ -142,6 +147,7 @@ if [ ! -z ${TEST+x} ]; then
   assert_eq "20190415" "$datestring"
   assert_eq "2fed83dee8" "$commit"
   assert_eq "https://nodejs.org/download/test/" "$release_urlbase"
+  assert_eq "https://nodejs.org/download/test/v12.0.1-test201904152fed83dee8" "$source_urlbase"
   assert_eq "https://nodejs.org/download/test/v12.0.1-test201904152fed83dee8/node-v12.0.1-test201904152fed83dee8.tar.xz" "$source_url"
 
   decode "v12.0.0-test20190116irp-mode-implementation"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -96,7 +96,7 @@ mkdir -p $distoutdir
 docker run --rm \
   -v "${sourcedir}:/out" \
   "${image_tag_pfx}fetch-source" \
-  "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url" \
+  "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url" "$source_urlbase" \
   > "${thislogdir}/fetch-source.log" 2>&1
 
 # Build all other recipes
@@ -122,7 +122,7 @@ for recipe in "${recipes_to_build[@]}"; do
   docker run --rm \
     -v "$ccachemount" -v "$sourcemount" -v "$stagingmount" \
     "${image_tag_pfx}${recipe}" \
-    "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url" \
+    "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url" "$source_urlbase" \
     > "${thislogdir}/${recipe}.log" 2>&1 || echo "Failed to build recipe for ${recipe}"
 
   # Total runtime can be up to 10hr for a full recipe so do promotion and

--- a/bin/local_build.sh
+++ b/bin/local_build.sh
@@ -107,7 +107,7 @@ if [[ ! -f "$sourcefile" ]]; then
     --user=${USER_ID} \
     -v "${sourcedir}:/out" \
     "${image_tag_pfx}fetch-source" \
-    "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url"
+    "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url" "$source_urlbase"
   echo "Done, source tarball is at ${sourcefile}"
 else
   echo "Source tarball already exists at ${sourcefile}, skipping download"
@@ -124,5 +124,5 @@ docker run --rm \
   --user=${USER_ID} \
   -v "$ccachemount" -v "$sourcemount" -v "$stagingmount" \
   "${image_tag_pfx}${recipe}" \
-  "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url"
+  "$unofficial_release_urlbase" "$disttype" "$customtag" "$datestring" "$commit" "$fullversion" "$source_url" "$source_urlbase"
 echo "Successful build should result in assets in ${stagingoutdir}"

--- a/fetch-source/run.sh
+++ b/fetch-source/run.sh
@@ -10,6 +10,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags=
 
 cd /home/node
@@ -33,7 +34,7 @@ for ((i=1;i<=7;i++)); do
 done
 
 if [[ "$disttype" = "release" ]]; then
-  curl -fsSLO --compressed "${source_url}/../SHASUMS256.txt.asc"
+  curl -fsSLO --compressed "${source_urlbase}/SHASUMS256.txt.asc"
   gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
   grep " node-${fullversion}.tar.xz\$" SHASUMS256.txt | sha256sum -c -
 fi

--- a/recipes/armv6l/run.sh
+++ b/recipes/armv6l/run.sh
@@ -10,6 +10,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags=
 
 cd /home/node

--- a/recipes/headers/run.sh
+++ b/recipes/headers/run.sh
@@ -9,6 +9,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags=
 
 cd /home/node
@@ -21,11 +22,11 @@ for key in ${gpg_keys}; do
       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
 done
 
-curl -fsSLO --compressed "${source_url}/../node-${fullversion}-headers.tar.gz"
-curl -fsSLO --compressed "${source_url}/../node-${fullversion}-headers.tar.xz"
+curl -fsSLO --compressed "${source_urlbase}/node-${fullversion}-headers.tar.gz"
+curl -fsSLO --compressed "${source_urlbase}/node-${fullversion}-headers.tar.xz"
 
 if [[ "$disttype" = "release" ]]; then
-  curl -fsSLO --compressed "${source_url}/../SHASUMS256.txt.asc"
+  curl -fsSLO --compressed "${source_urlbase}/SHASUMS256.txt.asc"
   gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
   grep " node-${fullversion}-headers.tar.*\$" SHASUMS256.txt | sha256sum -c -
 fi

--- a/recipes/loong64/run.sh
+++ b/recipes/loong64/run.sh
@@ -10,6 +10,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags="--openssl-no-asm"
 
 cd /home/node

--- a/recipes/musl/run.sh
+++ b/recipes/musl/run.sh
@@ -9,6 +9,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags=
 
 cd /home/node

--- a/recipes/riscv64/run.sh
+++ b/recipes/riscv64/run.sh
@@ -10,6 +10,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags="--openssl-no-asm"
 
 cd /home/node

--- a/recipes/x64-debug/run.sh
+++ b/recipes/x64-debug/run.sh
@@ -10,6 +10,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags="--gdb --debug --debug-node"
 
 cd /home/node

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -10,6 +10,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags=""
 
 cd /home/node

--- a/recipes/x64-pointer-compression/run.sh
+++ b/recipes/x64-pointer-compression/run.sh
@@ -10,6 +10,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags=--experimental-enable-pointer-compression
 
 cd /home/node

--- a/recipes/x64-usdt/run.sh
+++ b/recipes/x64-usdt/run.sh
@@ -10,6 +10,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags=--with-dtrace
 
 cd /home/node

--- a/recipes/x86/run.sh
+++ b/recipes/x86/run.sh
@@ -10,6 +10,7 @@ datestring="$4"
 commit="$5"
 fullversion="$6"
 source_url="$7"
+source_urlbase="$8"
 config_flags=--openssl-no-asm
 
 cd /home/node


### PR DESCRIPTION
Closes: https://github.com/nodejs/unofficial-builds/issues/160