### PR TITLE
build: use Ubuntu 24.04 and gcc-14 for LoongArch64 builds

### DIFF
--- a/recipes/loong64/Dockerfile
+++ b/recipes/loong64/Dockerfile
@@ -1,27 +1,32 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ARG GID=1000
 ARG UID=1000
-
-RUN addgroup --gid $GID node \
-    && adduser --gid $GID --uid $UID --disabled-password --gecos node node
 
 RUN apt-get update \
     && apt-get dist-upgrade -y \
     && apt-get install -y software-properties-common \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update \
     && apt-get install -y \
+         adduser \
          git \
 	 g++-13 \
          curl \
          make \
-         python3 \
-	 python3-distutils \
+         python3.10 \
          ccache \
-         xz-utils
+         xz-utils \
+         g++-14-loongarch64-linux-gnu \
+         gcc-14-loongarch64-linux-gnu-base \
+         gcc-14-loongarch64-linux-gnu
 
-RUN curl -L https://github.com/loongson/build-tools/releases/download/2024.11.01/x86_64-cross-tools-loongarch64-binutils_2.43.1-gcc_14.2.0-glibc_2.40.tar.xz | tar xJf - -C /opt
+RUN addgroup --gid $GID node \
+    && adduser --gid $GID --uid $UID --disabled-password --gecos node node
+
+RUN rm -f /usr/bin/python3
+RUN ln -s /usr/bin/python3.10 /usr/bin/python3
 
 COPY --chown=node:node run.sh /home/node/run.sh
 

--- a/recipes/loong64/run.sh
+++ b/recipes/loong64/run.sh
@@ -20,8 +20,8 @@ cd "node-${fullversion}"
 
 export CC_host="ccache gcc-13"
 export CXX_host="ccache g++-13"
-export CC="ccache /opt/cross-tools/bin/loongarch64-unknown-linux-gnu-gcc"
-export CXX="ccache /opt/cross-tools/bin/loongarch64-unknown-linux-gnu-g++"
+export CC="ccache /usr/bin/loongarch64-linux-gnu-gcc-14"
+export CXX="ccache /usr/bin/loongarch64-linux-gnu-g++-14"
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="loong64" \

--- a/recipes/loong64/should-build.sh
+++ b/recipes/loong64/should-build.sh
@@ -7,4 +7,8 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "18" && test "$major" -lt "22"
+(test "$major" -eq "18" && test "$minor" -ge "18") || \
+(test "$major" -eq "20" && test "$minor" -ge "10") || \
+(test "$major" -eq "21") || \
+(test "$major" -eq "22" && test "$minor" -ge "14") || \
+(test "$major" -ge "23")


### PR DESCRIPTION
The build of the LoongArch64 architecture has been stopped for a while, and the problem affecting the build has been fixed.
I tested the _**v18.x**~**24.x**_ versions in the new environment

1. Migrated build environment to `ubuntu:24.04` base image  
2. Adopted `gcc-14-loongarch64-linux-gnu` and `g++-14-loongarch64-linux-gnu` toolchains for LoongArch64 architecture builds  
3. Executed comprehensive builds using `./bin/local_build.sh -r loong64 -v $version` across Node.js versions 18.x to 24.x
Verified Build Success:

|   | Version Range | Build Status | Notes|
|-------|-------|-------|----------|
| 18.x | v18.18.0 - v18.20.6 |Successful |  v18.20.7~ requires simdutf ≥6.2.1(https://github.com/nodejs/node/issues/56280#issuecomment-2709233410) |
| 20.x | v20.10.0 - v20.19.2(current)  | Successful |
| 21.x | v21.0.0 - v21.7.3(EOL)	 | Successful |
| 22.x | v22.14.0 - v22.16.0(current) | Successful |
| 23.x | v23.9.0 - v23.11.1 (current) | Successful|
| 24.x | v24.0.0 - v24.1.0(current) | Successful|

I modified `recipes/loong64/should-build.sh` to determine the **node** version

What should I do to restore the **loong64** architecture build?

Best regards