### PR TITLE
Fix CentOS 7 recipes (x64-glibc-217 & x64-pointer-compression & x86)

### DIFF
--- a/bin/copy-recipes.sh
+++ b/bin/copy-recipes.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -eu
+
+# Copies files from recipes/x64-glibc-217 to:
+#     recipes/x64-pointer-compression
+#     recipes/x86
+
+__dirname="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+recipesDir="$(dirname "$__dirname")/recipes"
+srcRecipeDir="$recipesDir/x64-glibc-217"
+
+
+
+# Copy to x64-pointer-compression
+
+for dirBase in x64-pointer-compression; do
+	  destRecipeDir="$recipesDir/$dirBase"
+	  mkdir -p "$destRecipeDir/files"
+	
+	  cp -f  "$srcRecipeDir/Dockerfile"      "$destRecipeDir/"
+	  cp -f  "$srcRecipeDir/run.sh"          "$destRecipeDir/"
+	# cp -f  "$srcRecipeDir/run_other.sh"    "$destRecipeDir/"  # Recipe specific code
+	  cp -f  "$srcRecipeDir/run_versions.sh" "$destRecipeDir/"
+	# cp -f  "$srcRecipeDir/should-build.sh" "$destRecipeDir/"  # Pointer compression is supported from v13.4
+	  cp -rf "$srcRecipeDir/files/"*         "$destRecipeDir/files/"
+done
+
+
+
+# Copy to x86
+
+if true; then
+	  destRecipeDir="$recipesDir/x86"
+	  mkdir -p "$destRecipeDir/files"
+	  
+	  cp -f  "$srcRecipeDir/Dockerfile"      "$destRecipeDir/"
+	  cp -f  "$srcRecipeDir/run.sh"          "$destRecipeDir/"
+	# cp -f  "$srcRecipeDir/run_other.sh"    "$destRecipeDir/"  # Recipe specific code
+	# cp -f  "$srcRecipeDir/run_versions.sh" "$destRecipeDir/"  # Different versions of programs are used  (because devtoolset-12 is not available)
+	# cp -f  "$srcRecipeDir/should-build.sh" "$destRecipeDir/"
+	  
+	# cp -f "$srcRecipeDir/files/"*.repo                "$destRecipeDir/files/"  # Different versions of programs are used  (because devtoolset-12 is not available)
+	# cp -f "$srcRecipeDir/files/installPrerequisites"  "$destRecipeDir/files/"  # Different versions of programs are used  (because devtoolset-12 is not available)
+	  cp -f "$srcRecipeDir/files/installFromSourceCode" "$destRecipeDir/files/"
+	  cp -f "$srcRecipeDir/files/opt__gcc15__enable"    "$destRecipeDir/files/"
+	  
+	  sed -i -e 's/ --platform=linux\/amd64 / --platform=linux\/386 /g'     "$destRecipeDir/Dockerfile"
+	  sed -i -E 's/# RUN (.* binutils )/RUN   \1/g'                         "$destRecipeDir/Dockerfile"
+	  sed -i -E 's/--build=x86_64-redhat-linux/--build=i686-redhat-linux/g' "$destRecipeDir/Dockerfile"
+	# sed -i -e 's/gcc-15.1.0/gcc-12.4.0/g'                                 "$destRecipeDir/Dockerfile"
+	# sed -i -e 's/gcc15/gcc12/g'                                           "$destRecipeDir/Dockerfile"  "$destRecipeDir/files/opt__gcc12__enable"  "$destRecipeDir/files/installFromSourceCode"
+	  sed -i -e 's/devtoolset-12/devtoolset-9/g'                            "$destRecipeDir/files/opt__gcc"*'__enable'
+fi

--- a/recipes/x64-glibc-217/Dockerfile
+++ b/recipes/x64-glibc-217/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM --platform=linux/amd64 centos:7
 
 ARG GID=1000
 ARG UID=1000
@@ -6,34 +6,18 @@ ARG UID=1000
 RUN groupadd --gid $GID node \
     && adduser --gid $GID --uid $UID node
 
-RUN cat <<EOF | tee -a /etc/yum.repos.d/devtoolset-12.repo
-[devtoolset-12]
-name=Devtoolset 12
-baseurl=https://buildlogs.centos.org/c7-devtoolset-12.x86_64/
-enabled=1
-gpgcheck=0
-EOF
+COPY --chmod=755  files/installPrerequisites  /root/installPrerequisites
+COPY              files/*.repo                /etc/yum.repos.d/
+RUN /root/installPrerequisites
 
-RUN ulimit -n 1024 \
-    && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
-    && yum install -y epel-release \
-    && yum install -y centos-release-scl-rh \
-    && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
-    && yum upgrade -y \
-    && yum install -y \
-         git \
-         curl \
-         make \
-         python2 \
-         rh-python38 \
-         ccache \
-         xz-utils \
-         devtoolset-12 \
-         glibc-devel
+COPY  --chmod=755  files/installFromSourceCode  /root/installFromSourceCode
+COPY  --chmod=755  files/opt__gcc15__enable     /opt/gcc15/enable
+RUN   --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  python3   https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tar.xz      '--prefix=/usr/local/'
+RUN   --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  python3   https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tar.xz      '--prefix=/usr/local/'
+RUN   --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  gcc       https://gcc.gnu.org/pub/gcc/releases/gcc-15.1.0/gcc-15.1.0.tar.xz  '--prefix=/opt/gcc15/  --with-default-libstdcxx-abi=gcc4-compatible  --enable-languages=c,c++  --enable-checking=release  --enable-gnu-indirect-function  --with-linker-hash-style=gnu  --disable-bootstrap  --disable-multilib  --build=x86_64-redhat-linux'
+# RUN --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  binutils  https://sourceware.org/pub/binutils/releases/binutils-2.44.tar.xz  '--prefix=/opt/gcc15/  --without-debuginfod  --disable-nls  LDFLAGS=-pthread'
 
-COPY --chown=node:node run.sh /home/node/run.sh
+COPY --chmod=755  --chown=node:node  run.sh  run_other.sh  run_versions.sh  /home/node/
 
 VOLUME /home/node/.ccache
 VOLUME /out

--- a/recipes/x64-glibc-217/files/etc__yum.repos.d__devtoolset.repo
+++ b/recipes/x64-glibc-217/files/etc__yum.repos.d__devtoolset.repo
@@ -1,0 +1,4 @@
+[devtoolset-12]
+name=Devtoolset 12
+baseurl=https://buildlogs.centos.org/c7-devtoolset-12.x86_64/
+gpgcheck=0

--- a/recipes/x64-glibc-217/files/installFromSourceCode
+++ b/recipes/x64-glibc-217/files/installFromSourceCode
@@ -1,0 +1,36 @@
+#!/bin/bash -eux
+
+# Calc vars
+
+ id="$1"
+url="$2"
+configureArgsStr="$3"
+
+base=$(basename "$url")
+name=${base%.*}
+name=${name%.tar}
+ ext=${base:${#name}}
+
+case "$ext" in
+  .tar.xz|.txz)   formatOpt=--xz;;
+  .tar.gz|.tgz)   formatOpt=--gzip;;
+  .tar.bz2|.tbz2) formatOpt=--bzip2;;
+  *)              formatOpt=--auto-compress
+esac
+
+# Run commands
+
+curl -fL "$url" | tar --extract --directory=/usr/src "$formatOpt"
+
+source /opt/gcc15/enable
+export CC='ccache gcc'
+export CXX='ccache g++'
+
+cd "/usr/src/$name"
+chmod +x ./contrib/download_prerequisites 2>/dev/null && ./contrib/download_prerequisites
+./configure $configureArgsStr
+make -j $(nproc)
+make install
+
+hash -r
+ccache -s > "/root/ccacheStat_$name.txt"

--- a/recipes/x64-glibc-217/files/installPrerequisites
+++ b/recipes/x64-glibc-217/files/installPrerequisites
@@ -1,0 +1,12 @@
+#!/bin/bash -eux
+
+sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+yum install -y epel-release  # Adds extra repos
+yum upgrade -y
+
+yum install -y bzip2         # Required to compile gcc
+yum install -y gcc-c++       # Required to compile Node.js v7-
+yum install -y make          # Allows compilation
+yum install -y ccache        # Allows caching
+yum install -y devtoolset-12 # Includes gcc 12.1.1

--- a/recipes/x64-glibc-217/files/opt__gcc15__enable
+++ b/recipes/x64-glibc-217/files/opt__gcc15__enable
@@ -1,0 +1,15 @@
+#!/bin/bash -eux
+
+DIR=/opt/gcc15
+
+source /opt/rh/devtoolset-12/enable
+
+export            PATH="$DIR/bin${PATH:+:${PATH}}"
+export         MANPATH="$DIR/share/man${MANPATH:+:${MANPATH}}"
+export        INFOPATH="$DIR/share/info${INFOPATH:+:${INFOPATH}}"
+export LD_LIBRARY_PATH="$DIR/lib64:$DIR/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export PKG_CONFIG_PATH="$DIR/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+
+if [ -f "$DIR/bin/gcc" ]; then
+	export LDFLAGS='-static-libstdc++'
+fi

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -43,6 +43,10 @@ cd "$nodeDir/deps/v8/src"
 
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
+isNodeVersionGE() {
+	printf "$2\n$fullversion" | sort -VC
+}
+
 source "$homeDir/run_other.sh"
 source "$homeDir/run_versions.sh"
 

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -1,7 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/bash -eux
 
-set -e
-set -x
+
+
+# Init
 
 release_urlbase="$1"
 disttype="$2"
@@ -11,37 +12,55 @@ commit="$5"
 fullversion="$6"
 source_url="$7"
 source_urlbase="$8"
-config_flags=""
 
-cd /home/node
+homeDir=/home/node
+nodeDir="$homeDir/node-$fullversion"
 
-tar -xf node.tar.xz
+tar --directory="$homeDir" -xf "$homeDir/node.tar.xz"
 
-# configuring cares correctly to not use sys/random.h on this target
-cd "node-${fullversion}"/deps/cares
-sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./config/linux/ares_config.h
-sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./config/linux/ares_config.h
 
-# fix https://github.com/c-ares/c-ares/issues/850
-if [[ "$(grep -o 'ARES_VERSION_STR "[^"]*"' ./include/ares_version.h | awk '{print $2}' | tr -d '"')" == "1.33.0" ]]; then
-  sed -i 's/MSG_FASTOPEN/TCP_FASTOPEN_CONNECT/g' ./src/lib/ares__socket.c
+
+# Patch the code
+
+# Configuring cares correctly to not use sys/random.h on this target
+cd "$nodeDir/deps/cares/config/linux"
+sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ares_config.h
+sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g'       ares_config.h
+
+# Fix https://github.com/c-ares/c-ares/issues/850
+cd "$nodeDir/deps/cares"
+if [[ "$(grep -o 'ARES_VERSION_STR "[^"]*"' include/ares_version.h | awk '{print $2}' | tr -d '"')" == "1.33.0" ]]; then
+  sed -i 's/MSG_FASTOPEN/TCP_FASTOPEN_CONNECT/g' src/lib/ares__socket.c
 fi
 
-cd /home/node
+# Linux implementation of experimental WASM memory control requires Linux 3.17 & glibc 2.27 so disable it
+cd "$nodeDir/deps/v8/src"
+[ -f d8/d8.cc ] && sed -i -e 's/#if V8_TARGET_OS_LINUX/#if false/g' wasm/wasm-objects.cc d8/d8.cc
 
-cd "node-${fullversion}"
 
-export CC="ccache gcc"
-export CXX="ccache g++"
+
+# Prepare to compile Node.js
+
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
-. /opt/rh/devtoolset-12/enable
-. /opt/rh/rh-python38/enable
+source "$homeDir/run_other.sh"
+source "$homeDir/run_versions.sh"
+
+setPython
+setGCC
+
+
+
+# Compile Node.js
+
+cd "$nodeDir"
+export CC='ccache gcc'
+export CXX='ccache g++'
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
-  DESTCPU="x64" \
-  ARCH="x64" \
-  VARIATION="glibc-217" \
+  DESTCPU="$destCPU" \
+  ARCH="$arch" \
+  VARIATION="$variation" \
   DISTTYPE="$disttype" \
   CUSTOMTAG="$customtag" \
   DATESTRING="$datestring" \
@@ -49,4 +68,5 @@ make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   RELEASE_URLBASE="$release_urlbase" \
   CONFIG_FLAGS="$config_flags"
 
+"$nodeDir/node" -p process.versions
 mv node-*.tar.?z /out/

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -72,5 +72,5 @@ make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   RELEASE_URLBASE="$release_urlbase" \
   CONFIG_FLAGS="$config_flags"
 
-"$nodeDir/node" -p process.versions
+"$nodeDir/node" -p process.versions  # Make sure there is no "Segmentation fault" error  (example: node v21.0~v21.2 x64-pointer-compression)
 mv node-*.tar.?z /out/

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -44,7 +44,7 @@ cd "$nodeDir/deps/v8/src"
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
 isNodeVersionGE() {
-	printf "$2\n$fullversion" | sort -VC
+	printf "$1\n$fullversion" | sort -VC
 }
 
 source "$homeDir/run_other.sh"

--- a/recipes/x64-glibc-217/run_other.sh
+++ b/recipes/x64-glibc-217/run_other.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eux
+
+config_flags=
+destCPU=x64
+arch=x64
+variation=glibc-217
+
+# export CFLAGS='-march=skylake'
+# export CXXFLAGS='-march=skylake'

--- a/recipes/x64-glibc-217/run_versions.sh
+++ b/recipes/x64-glibc-217/run_versions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -eux
+
+setPython() {
+	if [ "$MAJOR_VERSION" -ge 23 ]; then export PYTHON='python3.13';  return;  fi  # Python 3.13: Node.js v22.3  ~ latest (v24.3)
+	if [ "$MAJOR_VERSION" -ge 15 ]; then export PYTHON='python3.9';   return;  fi  # Python 3.9:  Node.js v14.14 ~ latest (v24.3)
+	if [ "$MAJOR_VERSION" -ge 4  ]; then export PYTHON='python2.7';   return;  fi  # Python 2.7:  Node.js v4.0   ~ v15.14 (latest)
+	
+	# Node.js v16.0 is first version not supporting Python 2.7 but supports Python 3.6 ~ 3.9 so Python 3.9 is chosen
+}
+
+setGCC() {
+	if [ "$MAJOR_VERSION" -ge 23 ]; then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
+	if [ "$MAJOR_VERSION" -ge 8  ]; then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v23.7
+	                                                                                       # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
+}

--- a/recipes/x64-glibc-217/run_versions.sh
+++ b/recipes/x64-glibc-217/run_versions.sh
@@ -1,15 +1,15 @@
 #!/bin/bash -eux
 
 setPython() {
-	if [ "$MAJOR_VERSION" -ge 23 ]; then export PYTHON='python3.13';  return;  fi  # Python 3.13: Node.js v22.3  ~ latest (v24.3)
-	if [ "$MAJOR_VERSION" -ge 15 ]; then export PYTHON='python3.9';   return;  fi  # Python 3.9:  Node.js v14.14 ~ latest (v24.3)
-	if [ "$MAJOR_VERSION" -ge 4  ]; then export PYTHON='python2.7';   return;  fi  # Python 2.7:  Node.js v4.0   ~ v15.14 (latest)
+	if isNodeVersionGE 'v22.3';  then export PYTHON='python3.13';  return;  fi  # Python 3.13: Node.js v22.3  ~ latest (v24.3)
+	if isNodeVersionGE 'v14.14'; then export PYTHON='python3.9';   return;  fi  # Python 3.9:  Node.js v14.14 ~ latest (v24.3)
+	if isNodeVersionGE 'v4.0';   then export PYTHON='python2.7';   return;  fi  # Python 2.7:  Node.js v4.0   ~ v15.14 (latest)
 	
 	# Node.js v16.0 is first version not supporting Python 2.7 but supports Python 3.6 ~ 3.9 so Python 3.9 is chosen
 }
 
 setGCC() {
-	if [ "$MAJOR_VERSION" -ge 23 ]; then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
-	if [ "$MAJOR_VERSION" -ge 8  ]; then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v23.7
-	                                                                                       # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
+	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
+	if isNodeVersionGE 'v8.0';   then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v23.7
+	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
 }

--- a/recipes/x64-glibc-217/run_versions.sh
+++ b/recipes/x64-glibc-217/run_versions.sh
@@ -10,6 +10,6 @@ setPython() {
 
 setGCC() {
 	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)
-	if isNodeVersionGE 'v8.0';   then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v22.2
+	if isNodeVersionGE 'v8.0';   then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v22.1
 	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14
 }

--- a/recipes/x64-glibc-217/run_versions.sh
+++ b/recipes/x64-glibc-217/run_versions.sh
@@ -9,7 +9,7 @@ setPython() {
 }
 
 setGCC() {
-	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
-	if isNodeVersionGE 'v8.0';   then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v23.7
-	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
+	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)
+	if isNodeVersionGE 'v8.0';   then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v22.2
+	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14
 }

--- a/recipes/x64-glibc-217/should-build.sh
+++ b/recipes/x64-glibc-217/should-build.sh
@@ -10,4 +10,4 @@ decode "$fullversion"
 [ "$major" -ge 7  ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )  # Node.js v6.1- cannot download required files due to broken links
 
 [ "$major" -ne 17 ]                                                  # GCC version between 4.8.5 and 12.1 is required but not installed
-[[ ! "$fullversion" =~ ^v22\.2\.) ]]                                 # GCC version between 12.1  and 15.1 is required but not installed
+[[ ! "$fullversion" =~ ^v22\.2\. ]]                                  # GCC version between 12.1  and 15.1 is required but not installed

--- a/recipes/x64-glibc-217/should-build.sh
+++ b/recipes/x64-glibc-217/should-build.sh
@@ -7,4 +7,5 @@ fullversion=$2
 
 decode "$fullversion"
 
-[ "$major" -ge 7 ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )
+[ "$major" -ge 7  ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )  # Node.js v6.1- cannot download required files due to broken links
+[ "$major" -ne 17 ]                                                  # Not supported neigher by GCC 12.1 nor GCC 4.8.5 (works with GCC 9.3)

--- a/recipes/x64-glibc-217/should-build.sh
+++ b/recipes/x64-glibc-217/should-build.sh
@@ -3,11 +3,15 @@
 __dirname=$1
 fullversion=$2
 
-. ${__dirname}/_decode_version.sh
+isNodeVersionGE() {
+	printf "$1\n$fullversion" | sort -VC
+}
 
-decode "$fullversion"
+isNodeVersionLT() {
+	! printf "$1\n$fullversion" | sort -VC
+}
 
-[ "$major" -ge 7  ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )  # Node.js v6.1- cannot download required files due to broken links
+isNodeVersionGE 'v6.2'                                      # Node.js v6.1- cannot download required files due to broken links
 
-[ "$major" -ne 17 ]                                                  # GCC version between 4.8.5 and 12.1 is required but not installed
-[[ ! "$fullversion" =~ ^v22\.2\. ]]                                  # GCC version between 12.1  and 15.1 is required but not installed
+! ( isNodeVersionGE 'v17.0'  && isNodeVersionLT 'v18.0'  )  # GCC version between 4.8.5 and 12.1 is required but not installed
+! ( isNodeVersionGE 'v22.2'  && isNodeVersionLT 'v22.3'  )  # GCC version between 12.1  and 15.1 is required but not installed

--- a/recipes/x64-glibc-217/should-build.sh
+++ b/recipes/x64-glibc-217/should-build.sh
@@ -7,4 +7,4 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "18"
+[ "$major" -ge 7 ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )

--- a/recipes/x64-glibc-217/should-build.sh
+++ b/recipes/x64-glibc-217/should-build.sh
@@ -11,7 +11,7 @@ isNodeVersionLT() {
 	! printf "$1\n$fullversion" | sort -VC
 }
 
-isNodeVersionGE 'v6.2'                                      # Node.js v6.1- cannot download required files due to broken links
+isNodeVersionGE 'v6.2'                                # Node.js v6.1- cannot download required files due to broken links
 
-! ( isNodeVersionGE 'v17.0'  && isNodeVersionLT 'v18.0'  )  # GCC version between 4.8.5 and 12.1 is required but not installed
-! ( isNodeVersionGE 'v22.2'  && isNodeVersionLT 'v22.3'  )  # GCC version between 12.1  and 15.1 is required but not installed
+isNodeVersionLT 'v17.0'  || isNodeVersionGE 'v18.0'   # Node.js v17   requires GCC version between 4.8.5 and 12.1 which is not installed
+isNodeVersionLT 'v22.2'  || isNodeVersionGE 'v22.3'   # Node.js v22.2 requires GCC version between 12.1  and 15.1 which is not installed

--- a/recipes/x64-glibc-217/should-build.sh
+++ b/recipes/x64-glibc-217/should-build.sh
@@ -8,4 +8,6 @@ fullversion=$2
 decode "$fullversion"
 
 [ "$major" -ge 7  ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )  # Node.js v6.1- cannot download required files due to broken links
+
 [ "$major" -ne 17 ]                                                  # GCC version between 4.8.5 and 12.1 is required but not installed
+[[ ! "$fullversion" =~ ^v22\.2\.) ]]                                 # GCC version between 12.1  and 15.1 is required but not installed

--- a/recipes/x64-glibc-217/should-build.sh
+++ b/recipes/x64-glibc-217/should-build.sh
@@ -8,4 +8,4 @@ fullversion=$2
 decode "$fullversion"
 
 [ "$major" -ge 7  ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )  # Node.js v6.1- cannot download required files due to broken links
-[ "$major" -ne 17 ]                                                  # Not supported neigher by GCC 12.1 nor GCC 4.8.5 (works with GCC 9.3)
+[ "$major" -ne 17 ]                                                  # GCC version between 4.8.5 and 12.1 is required but not installed

--- a/recipes/x64-pointer-compression/Dockerfile
+++ b/recipes/x64-pointer-compression/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM --platform=linux/amd64 centos:7
 
 ARG GID=1000
 ARG UID=1000
@@ -6,46 +6,18 @@ ARG UID=1000
 RUN groupadd --gid $GID node \
     && adduser --gid $GID --uid $UID node
 
-COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
+COPY --chmod=755  files/installPrerequisites  /root/installPrerequisites
+COPY              files/*.repo                /etc/yum.repos.d/
+RUN /root/installPrerequisites
 
-# patch repos and install base dependencies
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
-    && yum install -y epel-release \
-    && yum upgrade -y \
-    && yum install -y \
-         git \
-         curl \
-         make \
-         python2 \
-         ccache \
-         xz-utils \
-         devtoolset-8 \
-         devtoolset-9 \
-         glibc-devel
+COPY  --chmod=755  files/installFromSourceCode  /root/installFromSourceCode
+COPY  --chmod=755  files/opt__gcc15__enable     /opt/gcc15/enable
+RUN   --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  python3   https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tar.xz      '--prefix=/usr/local/'
+RUN   --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  python3   https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tar.xz      '--prefix=/usr/local/'
+RUN   --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  gcc       https://gcc.gnu.org/pub/gcc/releases/gcc-15.1.0/gcc-15.1.0.tar.xz  '--prefix=/opt/gcc15/  --with-default-libstdcxx-abi=gcc4-compatible  --enable-languages=c,c++  --enable-checking=release  --enable-gnu-indirect-function  --with-linker-hash-style=gnu  --disable-bootstrap  --disable-multilib  --build=x86_64-redhat-linux'
+# RUN --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  binutils  https://sourceware.org/pub/binutils/releases/binutils-2.44.tar.xz  '--prefix=/opt/gcc15/  --without-debuginfod  --disable-nls  LDFLAGS=-pthread'
 
-# installs c compiler dev tools and builds python >=3.8 from source as it is needed for node >=v22
-ENV PYTHON_VERSION="3.10.15"
-RUN yum groupinstall -y "Development Tools" \
-    && yum install -y \
-        gcc \
-        gcc-c++ \
-        make \
-        zlib-devel \
-        bzip2-devel \
-        openssl-devel \
-        libffi-devel \
-        sqlite-devel \
-        readline-devel \
-    && curl https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz -O \
-    && tar xzf Python-${PYTHON_VERSION}.tgz \
-    && cd Python-${PYTHON_VERSION} \
-    && ./configure --enable-optimizations \
-    && make altinstall \
-    && PYTHON_MAJOR_MINOR_VERSION=$(echo $PYTHON_VERSION | cut -d. -f1,2) \
-    && ln -sf /usr/local/bin/python${PYTHON_MAJOR_MINOR_VERSION} /usr/bin/python3
-
-COPY --chown=node:node run.sh /home/node/run.sh
+COPY --chmod=755  --chown=node:node  run.sh  run_other.sh  run_versions.sh  /home/node/
 
 VOLUME /home/node/.ccache
 VOLUME /out

--- a/recipes/x64-pointer-compression/cloudlinux.repo
+++ b/recipes/x64-pointer-compression/cloudlinux.repo
@@ -1,9 +1,0 @@
-[cloudlinux-sclo-devtoolset-8]
-name=Cloudlinux devtoolset-8
-baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-8/x86_64/
-gpgcheck=0
-
-[cloudlinux-sclo-devtoolset-9]
-name=Cloudlinux devtoolset-9
-baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/x86_64/
-gpgcheck=0

--- a/recipes/x64-pointer-compression/files/etc__yum.repos.d__devtoolset.repo
+++ b/recipes/x64-pointer-compression/files/etc__yum.repos.d__devtoolset.repo
@@ -1,0 +1,4 @@
+[devtoolset-12]
+name=Devtoolset 12
+baseurl=https://buildlogs.centos.org/c7-devtoolset-12.x86_64/
+gpgcheck=0

--- a/recipes/x64-pointer-compression/files/installFromSourceCode
+++ b/recipes/x64-pointer-compression/files/installFromSourceCode
@@ -1,0 +1,36 @@
+#!/bin/bash -eux
+
+# Calc vars
+
+ id="$1"
+url="$2"
+configureArgsStr="$3"
+
+base=$(basename "$url")
+name=${base%.*}
+name=${name%.tar}
+ ext=${base:${#name}}
+
+case "$ext" in
+  .tar.xz|.txz)   formatOpt=--xz;;
+  .tar.gz|.tgz)   formatOpt=--gzip;;
+  .tar.bz2|.tbz2) formatOpt=--bzip2;;
+  *)              formatOpt=--auto-compress
+esac
+
+# Run commands
+
+curl -fL "$url" | tar --extract --directory=/usr/src "$formatOpt"
+
+source /opt/gcc15/enable
+export CC='ccache gcc'
+export CXX='ccache g++'
+
+cd "/usr/src/$name"
+chmod +x ./contrib/download_prerequisites 2>/dev/null && ./contrib/download_prerequisites
+./configure $configureArgsStr
+make -j $(nproc)
+make install
+
+hash -r
+ccache -s > "/root/ccacheStat_$name.txt"

--- a/recipes/x64-pointer-compression/files/installPrerequisites
+++ b/recipes/x64-pointer-compression/files/installPrerequisites
@@ -1,0 +1,12 @@
+#!/bin/bash -eux
+
+sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+yum install -y epel-release  # Adds extra repos
+yum upgrade -y
+
+yum install -y bzip2         # Required to compile gcc
+yum install -y gcc-c++       # Required to compile Node.js v7-
+yum install -y make          # Allows compilation
+yum install -y ccache        # Allows caching
+yum install -y devtoolset-12 # Includes gcc 12.1.1

--- a/recipes/x64-pointer-compression/files/opt__gcc15__enable
+++ b/recipes/x64-pointer-compression/files/opt__gcc15__enable
@@ -1,0 +1,15 @@
+#!/bin/bash -eux
+
+DIR=/opt/gcc15
+
+source /opt/rh/devtoolset-12/enable
+
+export            PATH="$DIR/bin${PATH:+:${PATH}}"
+export         MANPATH="$DIR/share/man${MANPATH:+:${MANPATH}}"
+export        INFOPATH="$DIR/share/info${INFOPATH:+:${INFOPATH}}"
+export LD_LIBRARY_PATH="$DIR/lib64:$DIR/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export PKG_CONFIG_PATH="$DIR/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+
+if [ -f "$DIR/bin/gcc" ]; then
+	export LDFLAGS='-static-libstdc++'
+fi

--- a/recipes/x64-pointer-compression/run.sh
+++ b/recipes/x64-pointer-compression/run.sh
@@ -43,6 +43,10 @@ cd "$nodeDir/deps/v8/src"
 
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
+isNodeVersionGE() {
+	printf "$2\n$fullversion" | sort -VC
+}
+
 source "$homeDir/run_other.sh"
 source "$homeDir/run_versions.sh"
 

--- a/recipes/x64-pointer-compression/run.sh
+++ b/recipes/x64-pointer-compression/run.sh
@@ -1,7 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/bash -eux
 
-set -e
-set -x
+
+
+# Init
 
 release_urlbase="$1"
 disttype="$2"
@@ -11,33 +12,55 @@ commit="$5"
 fullversion="$6"
 source_url="$7"
 source_urlbase="$8"
-config_flags=--experimental-enable-pointer-compression
 
-cd /home/node
+homeDir=/home/node
+nodeDir="$homeDir/node-$fullversion"
 
-tar -xf node.tar.xz
+tar --directory="$homeDir" -xf "$homeDir/node.tar.xz"
 
-# configuring cares correctly to not use sys/random.h on this target
-cd "node-${fullversion}"/deps/cares/config/linux
-sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./ares_config.h
-sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./ares_config.h
 
-cd /home/node
 
-cd "node-${fullversion}"
+# Patch the code
 
-export CC="ccache gcc"
-export CXX="ccache g++"
-export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
+# Configuring cares correctly to not use sys/random.h on this target
+cd "$nodeDir/deps/cares/config/linux"
+sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ares_config.h
+sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g'       ares_config.h
 
-if [ $MAJOR_VERSION -ge 16 ]; then
-  . /opt/rh/devtoolset-9/enable
+# Fix https://github.com/c-ares/c-ares/issues/850
+cd "$nodeDir/deps/cares"
+if [[ "$(grep -o 'ARES_VERSION_STR "[^"]*"' include/ares_version.h | awk '{print $2}' | tr -d '"')" == "1.33.0" ]]; then
+  sed -i 's/MSG_FASTOPEN/TCP_FASTOPEN_CONNECT/g' src/lib/ares__socket.c
 fi
 
+# Linux implementation of experimental WASM memory control requires Linux 3.17 & glibc 2.27 so disable it
+cd "$nodeDir/deps/v8/src"
+[ -f d8/d8.cc ] && sed -i -e 's/#if V8_TARGET_OS_LINUX/#if false/g' wasm/wasm-objects.cc d8/d8.cc
+
+
+
+# Prepare to compile Node.js
+
+export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
+
+source "$homeDir/run_other.sh"
+source "$homeDir/run_versions.sh"
+
+setPython
+setGCC
+
+
+
+# Compile Node.js
+
+cd "$nodeDir"
+export CC='ccache gcc'
+export CXX='ccache g++'
+
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
-  DESTCPU="x64" \
-  ARCH="x64" \
-  VARIATION="pointer-compression" \
+  DESTCPU="$destCPU" \
+  ARCH="$arch" \
+  VARIATION="$variation" \
   DISTTYPE="$disttype" \
   CUSTOMTAG="$customtag" \
   DATESTRING="$datestring" \
@@ -45,4 +68,5 @@ make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   RELEASE_URLBASE="$release_urlbase" \
   CONFIG_FLAGS="$config_flags"
 
+"$nodeDir/node" -p process.versions
 mv node-*.tar.?z /out/

--- a/recipes/x64-pointer-compression/run.sh
+++ b/recipes/x64-pointer-compression/run.sh
@@ -72,5 +72,5 @@ make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   RELEASE_URLBASE="$release_urlbase" \
   CONFIG_FLAGS="$config_flags"
 
-"$nodeDir/node" -p process.versions
+"$nodeDir/node" -p process.versions  # Make sure there is no "Segmentation fault" error  (example: node v21.0~v21.2 x64-pointer-compression)
 mv node-*.tar.?z /out/

--- a/recipes/x64-pointer-compression/run.sh
+++ b/recipes/x64-pointer-compression/run.sh
@@ -44,7 +44,7 @@ cd "$nodeDir/deps/v8/src"
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
 isNodeVersionGE() {
-	printf "$2\n$fullversion" | sort -VC
+	printf "$1\n$fullversion" | sort -VC
 }
 
 source "$homeDir/run_other.sh"

--- a/recipes/x64-pointer-compression/run_other.sh
+++ b/recipes/x64-pointer-compression/run_other.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eux
+
+config_flags=--experimental-enable-pointer-compression
+destCPU=x64
+arch=x64
+variation=pointer-compression

--- a/recipes/x64-pointer-compression/run_versions.sh
+++ b/recipes/x64-pointer-compression/run_versions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -eux
+
+setPython() {
+	if [ "$MAJOR_VERSION" -ge 23 ]; then export PYTHON='python3.13';  return;  fi  # Python 3.13: Node.js v22.3  ~ latest (v24.3)
+	if [ "$MAJOR_VERSION" -ge 15 ]; then export PYTHON='python3.9';   return;  fi  # Python 3.9:  Node.js v14.14 ~ latest (v24.3)
+	if [ "$MAJOR_VERSION" -ge 4  ]; then export PYTHON='python2.7';   return;  fi  # Python 2.7:  Node.js v4.0   ~ v15.14 (latest)
+	
+	# Node.js v16.0 is first version not supporting Python 2.7 but supports Python 3.6 ~ 3.9 so Python 3.9 is chosen
+}
+
+setGCC() {
+	if [ "$MAJOR_VERSION" -ge 23 ]; then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
+	if [ "$MAJOR_VERSION" -ge 8  ]; then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v23.7
+	                                                                                       # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
+}

--- a/recipes/x64-pointer-compression/run_versions.sh
+++ b/recipes/x64-pointer-compression/run_versions.sh
@@ -1,15 +1,15 @@
 #!/bin/bash -eux
 
 setPython() {
-	if [ "$MAJOR_VERSION" -ge 23 ]; then export PYTHON='python3.13';  return;  fi  # Python 3.13: Node.js v22.3  ~ latest (v24.3)
-	if [ "$MAJOR_VERSION" -ge 15 ]; then export PYTHON='python3.9';   return;  fi  # Python 3.9:  Node.js v14.14 ~ latest (v24.3)
-	if [ "$MAJOR_VERSION" -ge 4  ]; then export PYTHON='python2.7';   return;  fi  # Python 2.7:  Node.js v4.0   ~ v15.14 (latest)
+	if isNodeVersionGE 'v22.3';  then export PYTHON='python3.13';  return;  fi  # Python 3.13: Node.js v22.3  ~ latest (v24.3)
+	if isNodeVersionGE 'v14.14'; then export PYTHON='python3.9';   return;  fi  # Python 3.9:  Node.js v14.14 ~ latest (v24.3)
+	if isNodeVersionGE 'v4.0';   then export PYTHON='python2.7';   return;  fi  # Python 2.7:  Node.js v4.0   ~ v15.14 (latest)
 	
 	# Node.js v16.0 is first version not supporting Python 2.7 but supports Python 3.6 ~ 3.9 so Python 3.9 is chosen
 }
 
 setGCC() {
-	if [ "$MAJOR_VERSION" -ge 23 ]; then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
-	if [ "$MAJOR_VERSION" -ge 8  ]; then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v23.7
-	                                                                                       # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
+	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
+	if isNodeVersionGE 'v8.0';   then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v23.7
+	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
 }

--- a/recipes/x64-pointer-compression/run_versions.sh
+++ b/recipes/x64-pointer-compression/run_versions.sh
@@ -10,6 +10,6 @@ setPython() {
 
 setGCC() {
 	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)
-	if isNodeVersionGE 'v8.0';   then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v22.2
+	if isNodeVersionGE 'v8.0';   then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v22.1
 	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14
 }

--- a/recipes/x64-pointer-compression/run_versions.sh
+++ b/recipes/x64-pointer-compression/run_versions.sh
@@ -9,7 +9,7 @@ setPython() {
 }
 
 setGCC() {
-	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
-	if isNodeVersionGE 'v8.0';   then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v23.7
-	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
+	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)
+	if isNodeVersionGE 'v8.0';   then source /opt/rh/devtoolset-12/enable; return;  fi  # GCC 12.1:  Node.js v8.0  ~ v22.2
+	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14
 }

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -12,6 +12,7 @@ decode "$fullversion"
 [ "$major" -ne 17 ]                                                   # GCC version between 4.8.5 and 12.1 is required but not installed
 [[ ! "$fullversion" =~ ^v22\.2\. ]]                                   # GCC version between 12.1  and 15.1 is required but not installed
 
-[ "$major" -ne 20 ] || [ "$minor" -le 16 ]                            # Pointer compression does not work in Node.js v20.17~v20.19 (Compilation error)
+[ "$major" -ne 20 ] || [ "$minor" -lt 17 ]                            # Pointer compression does not work in Node.js v20.17~v20.19 (Compilation error)
 [[ ! "$fullversion" =~ ^v21\.[0-2]\. ]]                               # Pointer compression does not work in Node.js v21.0~v21.2   (Segmentation fault)
+[ "$major" -ne 22 ] || [ "$minor" -lt 6 ] || [ "$minor" -gt 16 ]      # Pointer compression does not work in Node.js v22.6~v22.16  (Compilation error)
 [[ ! "$fullversion" =~ ^v(23|24\.[0-1]\.) ]]                          # Pointer compression does not work in Node.js v23.0~v24.1   (Compilation error)

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -7,7 +7,8 @@ fullversion=$2
 
 decode "$fullversion"
 
-[ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )
-[ "$major" -ne 20 ] || [ "$minor" -le 16 ]
-[ "$major" -ne 23 ]
-[[ ! "$fullversion" =~ ^v24\.[0-1]\. ]]
+[ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )  # Pointer compression is supported since Node.js v13.4
+[ "$major" -ne 17 ]                                                   # Not supported neigher by GCC 12.1 nor GCC 4.8.5 (works with GCC 9.3)
+[ "$major" -ne 20 ] || [ "$minor" -le 16 ]                            # Pointer compression does not work in Node.js v20.17~v20.19
+[ "$major" -ne 23 ]                                                   # Pointer compression does not work in Node.js v23.0~v24.1
+[[ ! "$fullversion" =~ ^v24\.[0-1]\. ]]                               # Pointer compression does not work in Node.js v23.0~v24.1

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -8,7 +8,7 @@ fullversion=$2
 decode "$fullversion"
 
 [ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )  # Pointer compression is supported since Node.js v13.4
-[ "$major" -ne 17 ]                                                   # Not supported neigher by GCC 12.1 nor GCC 4.8.5 (works with GCC 9.3)
+[ "$major" -ne 17 ]                                                   # GCC version between 4.8.5 and 12.1 is required but not installed
 [ "$major" -ne 20 ] || [ "$minor" -le 16 ]                            # Pointer compression does not work in Node.js v20.17~v20.19
 [ "$major" -ne 23 ]                                                   # Pointer compression does not work in Node.js v23.0~v24.1
 [[ ! "$fullversion" =~ ^v24\.[0-1]\. ]]                               # Pointer compression does not work in Node.js v23.0~v24.1

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -10,7 +10,7 @@ decode "$fullversion"
 [ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )  # Pointer compression is supported since Node.js v13.4
 
 [ "$major" -ne 17 ]                                                   # GCC version between 4.8.5 and 12.1 is required but not installed
-[[ ! "$fullversion" =~ ^v22\.2\.) ]]                                  # GCC version between 12.1  and 15.1 is required but not installed
+[[ ! "$fullversion" =~ ^v22\.2\. ]]                                   # GCC version between 12.1  and 15.1 is required but not installed
 
 [ "$major" -ne 20 ] || [ "$minor" -le 16 ]                            # Pointer compression does not work in Node.js v20.17~v20.19
 [[ ! "$fullversion" =~ ^v(23|24\.[0-1]\.) ]]                          # Pointer compression does not work in Node.js v23.0~v24.1

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -10,5 +10,4 @@ decode "$fullversion"
 [ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )  # Pointer compression is supported since Node.js v13.4
 [ "$major" -ne 17 ]                                                   # GCC version between 4.8.5 and 12.1 is required but not installed
 [ "$major" -ne 20 ] || [ "$minor" -le 16 ]                            # Pointer compression does not work in Node.js v20.17~v20.19
-[ "$major" -ne 23 ]                                                   # Pointer compression does not work in Node.js v23.0~v24.1
-[[ ! "$fullversion" =~ ^v24\.[0-1]\. ]]                               # Pointer compression does not work in Node.js v23.0~v24.1
+[[ ! "$fullversion" =~ ^v(23|24\.[0-1]\.) ]]                          # Pointer compression does not work in Node.js v23.0~v24.1

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -3,16 +3,20 @@
 __dirname=$1
 fullversion=$2
 
-. ${__dirname}/_decode_version.sh
+isNodeVersionGE() {
+	printf "$1\n$fullversion" | sort -VC
+}
 
-decode "$fullversion"
+isNodeVersionLT() {
+	! printf "$1\n$fullversion" | sort -VC
+}
 
-[ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )  # Pointer compression is supported since Node.js v13.4
+isNodeVersionGE 'v13.4'                                     # Pointer compression is supported since Node.js v13.4
 
-[ "$major" -ne 17 ]                                                   # GCC version between 4.8.5 and 12.1 is required but not installed
-[[ ! "$fullversion" =~ ^v22\.2\. ]]                                   # GCC version between 12.1  and 15.1 is required but not installed
+! ( isNodeVersionGE 'v17.0'  && isNodeVersionLT 'v18.0'  )  # GCC version between 4.8.5 and 12.1 is required but not installed
+! ( isNodeVersionGE 'v22.2'  && isNodeVersionLT 'v22.3'  )  # GCC version between 12.1  and 15.1 is required but not installed
 
-[ "$major" -ne 20 ] || [ "$minor" -lt 17 ]                            # Pointer compression does not work in Node.js v20.17~v20.19 (Compilation error)
-[[ ! "$fullversion" =~ ^v21\.[0-2]\. ]]                               # Pointer compression does not work in Node.js v21.0~v21.2   (Segmentation fault)
-[ "$major" -ne 22 ] || [ "$minor" -lt 6 ] || [ "$minor" -gt 16 ]      # Pointer compression does not work in Node.js v22.6~v22.16  (Compilation error)
-[[ ! "$fullversion" =~ ^v(23|24\.[0-1]\.) ]]                          # Pointer compression does not work in Node.js v23.0~v24.1   (Compilation error)
+! ( isNodeVersionGE 'v20.17' && isNodeVersionLT 'v21.0'  )  # Pointer compression does not work in Node.js v20.17~v20.19 (Compilation error)
+! ( isNodeVersionGE 'v21.0'  && isNodeVersionLT 'v21.3'  )  # Pointer compression does not work in Node.js v21.0~v21.2   (Segmentation fault)
+! ( isNodeVersionGE 'v22.6'  && isNodeVersionLT 'v22.17' )  # Pointer compression does not work in Node.js v22.6~v22.16  (Compilation error)
+! ( isNodeVersionGE 'v23.0'  && isNodeVersionLT 'v24.2'  )  # Pointer compression does not work in Node.js v23.0~v24.1   (Compilation error)

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -8,3 +8,5 @@ fullversion=$2
 decode "$fullversion"
 
 [ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )
+[ "$major" -ne 20 ] || [ "$minor" -le 16 ]
+[ "$major" -ne 23 ] || [ "$minor" -le 7 ]

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -11,12 +11,12 @@ isNodeVersionLT() {
 	! printf "$1\n$fullversion" | sort -VC
 }
 
-isNodeVersionGE 'v13.4'                                     # Pointer compression is supported since Node.js v13.4
+isNodeVersionGE 'v13.4'                               # Pointer compression is supported since Node.js v13.4
 
-! ( isNodeVersionGE 'v17.0'  && isNodeVersionLT 'v18.0'  )  # GCC version between 4.8.5 and 12.1 is required but not installed
-! ( isNodeVersionGE 'v22.2'  && isNodeVersionLT 'v22.3'  )  # GCC version between 12.1  and 15.1 is required but not installed
+isNodeVersionLT 'v17.0'  || isNodeVersionGE 'v18.0'   # Node.js v17   requires GCC version between 4.8.5 and 12.1 which is not installed
+isNodeVersionLT 'v22.2'  || isNodeVersionGE 'v22.3'   # Node.js v22.2 requires GCC version between 12.1  and 15.1 which is not installed
 
-! ( isNodeVersionGE 'v20.17' && isNodeVersionLT 'v21.0'  )  # Pointer compression does not work in Node.js v20.17~v20.19 (Compilation error)
-! ( isNodeVersionGE 'v21.0'  && isNodeVersionLT 'v21.3'  )  # Pointer compression does not work in Node.js v21.0~v21.2   (Segmentation fault)
-! ( isNodeVersionGE 'v22.6'  && isNodeVersionLT 'v22.17' )  # Pointer compression does not work in Node.js v22.6~v22.16  (Compilation error)
-! ( isNodeVersionGE 'v23.0'  && isNodeVersionLT 'v24.2'  )  # Pointer compression does not work in Node.js v23.0~v24.1   (Compilation error)
+isNodeVersionLT 'v20.17' || isNodeVersionGE 'v21.0'   # Pointer compression does not work in Node.js v20.17~v20.19 (Compilation error)
+isNodeVersionLT 'v21.0'  || isNodeVersionGE 'v21.3'   # Pointer compression does not work in Node.js v21.0~v21.2   (Segmentation fault)
+isNodeVersionLT 'v22.6'  || isNodeVersionGE 'v22.17'  # Pointer compression does not work in Node.js v22.6~v22.16  (Compilation error)
+isNodeVersionLT 'v23.0'  || isNodeVersionGE 'v24.2'   # Pointer compression does not work in Node.js v23.0~v24.1   (Compilation error)

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -10,3 +10,4 @@ decode "$fullversion"
 [ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )
 [ "$major" -ne 20 ] || [ "$minor" -le 16 ]
 [ "$major" -ne 23 ]
+[[ ! "$fullversion" =~ ^v24\.[0-1]\. ]]

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -9,4 +9,4 @@ decode "$fullversion"
 
 [ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )
 [ "$major" -ne 20 ] || [ "$minor" -le 16 ]
-[ "$major" -ne 23 ] || [ "$minor" -le 7 ]
+[ "$major" -ne 23 ]

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -12,5 +12,6 @@ decode "$fullversion"
 [ "$major" -ne 17 ]                                                   # GCC version between 4.8.5 and 12.1 is required but not installed
 [[ ! "$fullversion" =~ ^v22\.2\. ]]                                   # GCC version between 12.1  and 15.1 is required but not installed
 
-[ "$major" -ne 20 ] || [ "$minor" -le 16 ]                            # Pointer compression does not work in Node.js v20.17~v20.19
-[[ ! "$fullversion" =~ ^v(23|24\.[0-1]\.) ]]                          # Pointer compression does not work in Node.js v23.0~v24.1
+[ "$major" -ne 20 ] || [ "$minor" -le 16 ]                            # Pointer compression does not work in Node.js v20.17~v20.19 (Compilation error)
+[[ ! "$fullversion" =~ ^v21\.[0-2]\. ]]                               # Pointer compression does not work in Node.js v21.0~v21.2   (Segmentation fault)
+[[ ! "$fullversion" =~ ^v(23|24\.[0-1]\.) ]]                          # Pointer compression does not work in Node.js v23.0~v24.1   (Compilation error)

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -7,4 +7,4 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "14" && test "$major" -lt "23"
+[ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )

--- a/recipes/x64-pointer-compression/should-build.sh
+++ b/recipes/x64-pointer-compression/should-build.sh
@@ -8,6 +8,9 @@ fullversion=$2
 decode "$fullversion"
 
 [ "$major" -ge 14 ] || ( [ "$major" -eq 13 ] && [ "$minor" -ge 4 ] )  # Pointer compression is supported since Node.js v13.4
+
 [ "$major" -ne 17 ]                                                   # GCC version between 4.8.5 and 12.1 is required but not installed
+[[ ! "$fullversion" =~ ^v22\.2\.) ]]                                  # GCC version between 12.1  and 15.1 is required but not installed
+
 [ "$major" -ne 20 ] || [ "$minor" -le 16 ]                            # Pointer compression does not work in Node.js v20.17~v20.19
 [[ ! "$fullversion" =~ ^v(23|24\.[0-1]\.) ]]                          # Pointer compression does not work in Node.js v23.0~v24.1

--- a/recipes/x86/Dockerfile
+++ b/recipes/x86/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM --platform=linux/386 centos:7
 
 ARG GID=1000
 ARG UID=1000
@@ -6,25 +6,18 @@ ARG UID=1000
 RUN groupadd --gid $GID node \
     && adduser --gid $GID --uid $UID node
 
-COPY cloudlinux.repo /etc/yum.repos.d/cloudlinux.repo
+COPY --chmod=755  files/installPrerequisites  /root/installPrerequisites
+COPY              files/*.repo                /etc/yum.repos.d/
+RUN /root/installPrerequisites
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
-    && yum install -y epel-release \
-    && yum upgrade -y \
-    && yum install -y \
-         git \
-         curl \
-         make \
-         python2 \
-         python3 \
-         ccache \
-         xz-utils \
-         devtoolset-6.i686 \
-         devtoolset-9.i686 \
-         glibc-devel.i686
+COPY  --chmod=755  files/installFromSourceCode  /root/installFromSourceCode
+COPY  --chmod=755  files/opt__gcc15__enable     /opt/gcc15/enable
+RUN   --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  python3   https://www.python.org/ftp/python/3.9.23/Python-3.9.23.tar.xz      '--prefix=/usr/local/'
+RUN   --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  python3   https://www.python.org/ftp/python/3.13.5/Python-3.13.5.tar.xz      '--prefix=/usr/local/'
+RUN   --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  gcc       https://gcc.gnu.org/pub/gcc/releases/gcc-15.1.0/gcc-15.1.0.tar.xz  '--prefix=/opt/gcc15/  --with-default-libstdcxx-abi=gcc4-compatible  --enable-languages=c,c++  --enable-checking=release  --enable-gnu-indirect-function  --with-linker-hash-style=gnu  --disable-bootstrap  --disable-multilib  --build=i686-redhat-linux'
+RUN   --mount=type=cache,target=/root/.ccache  --mount=type=tmpfs,target=/usr/src  /root/installFromSourceCode  binutils  https://sourceware.org/pub/binutils/releases/binutils-2.44.tar.xz  '--prefix=/opt/gcc15/  --without-debuginfod  --disable-nls  LDFLAGS=-pthread'
 
-COPY --chown=node:node run.sh /home/node/run.sh
+COPY --chmod=755  --chown=node:node  run.sh  run_other.sh  run_versions.sh  /home/node/
 
 VOLUME /home/node/.ccache
 VOLUME /out

--- a/recipes/x86/cloudlinux.repo
+++ b/recipes/x86/cloudlinux.repo
@@ -1,9 +1,0 @@
-[cloudlinux-sclo-devtoolset-6]
-name=Cloudlinux devtoolset-6
-baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-6/i386/
-gpgcheck=0
-
-[cloudlinux-sclo-devtoolset-9]
-name=Cloudlinux devtoolset-9
-baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/i386/
-gpgcheck=0

--- a/recipes/x86/files/etc__yum.repos.d__devtoolset.repo
+++ b/recipes/x86/files/etc__yum.repos.d__devtoolset.repo
@@ -1,0 +1,4 @@
+[cloudlinux-sclo-devtoolset-9]
+name=Cloudlinux devtoolset-9
+baseurl=https://repo.cloudlinux.com/cloudlinux/7/sclo/devtoolset-9/i386/
+gpgcheck=0

--- a/recipes/x86/files/etc__yum.repos.d__epel.repo
+++ b/recipes/x86/files/etc__yum.repos.d__epel.repo
@@ -1,0 +1,4 @@
+[epel]
+name=epel
+baseurl=https://buildlogs.centos.org/c7-epel.i386/
+gpgcheck=0

--- a/recipes/x86/files/installFromSourceCode
+++ b/recipes/x86/files/installFromSourceCode
@@ -1,0 +1,36 @@
+#!/bin/bash -eux
+
+# Calc vars
+
+ id="$1"
+url="$2"
+configureArgsStr="$3"
+
+base=$(basename "$url")
+name=${base%.*}
+name=${name%.tar}
+ ext=${base:${#name}}
+
+case "$ext" in
+  .tar.xz|.txz)   formatOpt=--xz;;
+  .tar.gz|.tgz)   formatOpt=--gzip;;
+  .tar.bz2|.tbz2) formatOpt=--bzip2;;
+  *)              formatOpt=--auto-compress
+esac
+
+# Run commands
+
+curl -fL "$url" | tar --extract --directory=/usr/src "$formatOpt"
+
+source /opt/gcc15/enable
+export CC='ccache gcc'
+export CXX='ccache g++'
+
+cd "/usr/src/$name"
+chmod +x ./contrib/download_prerequisites 2>/dev/null && ./contrib/download_prerequisites
+./configure $configureArgsStr
+make -j $(nproc)
+make install
+
+hash -r
+ccache -s > "/root/ccacheStat_$name.txt"

--- a/recipes/x86/files/installPrerequisites
+++ b/recipes/x86/files/installPrerequisites
@@ -1,0 +1,16 @@
+#!/bin/bash -eux
+
+sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+yum upgrade -y
+
+yum install -y bzip2             # Required to compile gcc
+yum install -y zlib-devel        # Required to compile Python
+yum install -y bzip2-devel       # Required to compile Python with bz2 module (required by Node.js)
+yum install -y gcc-c++           # Required to compile Node.js v7-
+yum install -y make              # Allows compilation
+yum install -y ccache            # Allows caching
+yum install -y devtoolset-9.i686 # Includes gcc 9.3.1
+
+# Fix bugs
+sed -i -e 's/:\${MANPATH}/\${MANPATH:+:\${MANPATH}}/g' /opt/rh/devtoolset-9/enable

--- a/recipes/x86/files/opt__gcc15__enable
+++ b/recipes/x86/files/opt__gcc15__enable
@@ -1,0 +1,15 @@
+#!/bin/bash -eux
+
+DIR=/opt/gcc15
+
+source /opt/rh/devtoolset-9/enable
+
+export            PATH="$DIR/bin${PATH:+:${PATH}}"
+export         MANPATH="$DIR/share/man${MANPATH:+:${MANPATH}}"
+export        INFOPATH="$DIR/share/info${INFOPATH:+:${INFOPATH}}"
+export LD_LIBRARY_PATH="$DIR/lib64:$DIR/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export PKG_CONFIG_PATH="$DIR/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+
+if [ -f "$DIR/bin/gcc" ]; then
+	export LDFLAGS='-static-libstdc++'
+fi

--- a/recipes/x86/run.sh
+++ b/recipes/x86/run.sh
@@ -43,6 +43,10 @@ cd "$nodeDir/deps/v8/src"
 
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
+isNodeVersionGE() {
+	printf "$2\n$fullversion" | sort -VC
+}
+
 source "$homeDir/run_other.sh"
 source "$homeDir/run_versions.sh"
 

--- a/recipes/x86/run.sh
+++ b/recipes/x86/run.sh
@@ -1,7 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/bash -eux
 
-set -e
-set -x
+
+
+# Init
 
 release_urlbase="$1"
 disttype="$2"
@@ -11,35 +12,55 @@ commit="$5"
 fullversion="$6"
 source_url="$7"
 source_urlbase="$8"
-config_flags=--openssl-no-asm
 
-cd /home/node
+homeDir=/home/node
+nodeDir="$homeDir/node-$fullversion"
 
-tar -xf node.tar.xz
+tar --directory="$homeDir" -xf "$homeDir/node.tar.xz"
 
-# configuring cares correctly to not use sys/random.h on this target
-cd "node-${fullversion}"/deps/cares/config/linux
-sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./ares_config.h
-sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./ares_config.h
 
-cd /home/node
 
-cd "node-${fullversion}"
+# Patch the code
 
-export CC="ccache gcc"
-export CXX="ccache g++"
-export CXXFLAGS=-m32
-export CFLAGS=-m32
-export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
+# Configuring cares correctly to not use sys/random.h on this target
+cd "$nodeDir/deps/cares/config/linux"
+sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ares_config.h
+sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g'       ares_config.h
 
-if [ $MAJOR_VERSION -ge 16 ]; then
-  . /opt/rh/devtoolset-9/enable
+# Fix https://github.com/c-ares/c-ares/issues/850
+cd "$nodeDir/deps/cares"
+if [[ "$(grep -o 'ARES_VERSION_STR "[^"]*"' include/ares_version.h | awk '{print $2}' | tr -d '"')" == "1.33.0" ]]; then
+  sed -i 's/MSG_FASTOPEN/TCP_FASTOPEN_CONNECT/g' src/lib/ares__socket.c
 fi
 
+# Linux implementation of experimental WASM memory control requires Linux 3.17 & glibc 2.27 so disable it
+cd "$nodeDir/deps/v8/src"
+[ -f d8/d8.cc ] && sed -i -e 's/#if V8_TARGET_OS_LINUX/#if false/g' wasm/wasm-objects.cc d8/d8.cc
+
+
+
+# Prepare to compile Node.js
+
+export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
+
+source "$homeDir/run_other.sh"
+source "$homeDir/run_versions.sh"
+
+setPython
+setGCC
+
+
+
+# Compile Node.js
+
+cd "$nodeDir"
+export CC='ccache gcc'
+export CXX='ccache g++'
+
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
-  DESTCPU="x86" \
-  ARCH="x86" \
-  VARIATION="" \
+  DESTCPU="$destCPU" \
+  ARCH="$arch" \
+  VARIATION="$variation" \
   DISTTYPE="$disttype" \
   CUSTOMTAG="$customtag" \
   DATESTRING="$datestring" \
@@ -47,4 +68,5 @@ make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   RELEASE_URLBASE="$release_urlbase" \
   CONFIG_FLAGS="$config_flags"
 
+"$nodeDir/node" -p process.versions
 mv node-*.tar.?z /out/

--- a/recipes/x86/run.sh
+++ b/recipes/x86/run.sh
@@ -72,5 +72,5 @@ make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   RELEASE_URLBASE="$release_urlbase" \
   CONFIG_FLAGS="$config_flags"
 
-"$nodeDir/node" -p process.versions
+"$nodeDir/node" -p process.versions  # Make sure there is no "Segmentation fault" error  (example: node v21.0~v21.2 x64-pointer-compression)
 mv node-*.tar.?z /out/

--- a/recipes/x86/run.sh
+++ b/recipes/x86/run.sh
@@ -44,7 +44,7 @@ cd "$nodeDir/deps/v8/src"
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
 
 isNodeVersionGE() {
-	printf "$2\n$fullversion" | sort -VC
+	printf "$1\n$fullversion" | sort -VC
 }
 
 source "$homeDir/run_other.sh"

--- a/recipes/x86/run_other.sh
+++ b/recipes/x86/run_other.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -eux
+
+config_flags=
+destCPU=x86
+arch=x86
+variation=
+
+# GCC forbids SSE by default for x86 but it is required by Node.js so enable it manually
+export CFLAGS='-msse2'
+export CXXFLAGS='-msse2'
+# export CFLAGS='-msse4.2'           # This can be used too for modern       CPUs (~2008)
+# export CFLAGS='-mavx'              # This can be used too for modern       CPUs (~2011)
+# export CFLAGS='-mavx2'             # This can be used too for modern       CPUs (~2013)
+# export CFLAGS='-mavx2 -maes'       # This can be used too for modern       CPUs (~2015)
+# export CFLAGS='-march=znver1'      # This can be used too for modern AMD   CPUs (~2017)
+# export CFLAGS='-march=sandybridge' # This can be used too for modern Intel CPUs (~2011)
+
+# x86 does not support _mm_cvtsi128_si64 instruction so forbid it's usage and fallback to non-SSE solution
+cd "$nodeDir/deps/v8/src"
+find  .  -name '*.cc'  -type f  -print0  |  xargs -0 sed -i -e 's/#ifdef __SSE2__/#if false/g'
+
+# Replace %ifdef with #ifdef in assembler code
+cd "$nodeDir/deps/openssl/config/archs/linux-elf/asm" &&
+find  .  -name '*.S'  -type f  -print0  |  xargs -0 --no-run-if-empty sed -i -e 's/%ifdef/#ifdef/g' -e 's/%endif/#endif/g'
+
+# Fix https://github.com/nodejs/node/issues/58458
+str1='return __ Tuple<Word32, Word32>\(result, __ Word32Constant\(0\)\);'
+str2='V<Word32> result_ = result;   return __ Tuple\(result_, __ Word32Constant\(0\)\);'
+cd "$nodeDir/deps/v8/src/compiler/turboshaft" &&
+[ -f int64-lowering-reducer.h ] && sed -i -E "s/$str1/$str2/g" int64-lowering-reducer.h
+# https://github.com/nodejs/node/issues/58458#issuecomment-2916873746
+# https://github.com/nodejs/node/commit/02f8cdb0c7a73d970ed7134a481a211bbd599c02
+
+true  # To allow "&&" above

--- a/recipes/x86/run_versions.sh
+++ b/recipes/x86/run_versions.sh
@@ -9,10 +9,7 @@ setPython() {
 }
 
 setGCC() {
-	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
-	if isNodeVersionGE 'v7.10';  then source /opt/rh/devtoolset-9/enable;  return;  fi  # GCC 9.3:   Node.js v7.10 ~ v21.7 (latest)  (v20.0~v21.7 has compatibility warning by Node.js)
-	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
-	
-	# Node.js v22.0 is first version not supporting GCC 9.3 but supports GCC 12.4- so GCC 12.4
-	# should be chosen, but support of v22.0~v22.2 is dropped and GCC 15.1 is chosen instead
+	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)
+	if isNodeVersionGE 'v7.10';  then source /opt/rh/devtoolset-9/enable;  return;  fi  # GCC 9.3:   Node.js v7.10 ~ v21.7 (latest)
+	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14
 }

--- a/recipes/x86/run_versions.sh
+++ b/recipes/x86/run_versions.sh
@@ -1,17 +1,17 @@
 #!/bin/bash -eux
 
 setPython() {
-	if [ "$MAJOR_VERSION" -ge 23 ]; then export PYTHON='python3.13';  return;  fi  # Python 3.13: Node.js v22.3  ~ latest (v24.3)
-	if [ "$MAJOR_VERSION" -ge 15 ]; then export PYTHON='python3.9';   return;  fi  # Python 3.9:  Node.js v14.14 ~ latest (v24.3)
-	if [ "$MAJOR_VERSION" -ge 4  ]; then export PYTHON='python2.7';   return;  fi  # Python 2.7:  Node.js v4.0   ~ v15.14 (latest)
+	if isNodeVersionGE 'v22.3';  then export PYTHON='python3.13';  return;  fi  # Python 3.13: Node.js v22.3  ~ latest (v24.3)
+	if isNodeVersionGE 'v14.14'; then export PYTHON='python3.9';   return;  fi  # Python 3.9:  Node.js v14.14 ~ latest (v24.3)
+	if isNodeVersionGE 'v4.0';   then export PYTHON='python2.7';   return;  fi  # Python 2.7:  Node.js v4.0   ~ v15.14 (latest)
 	
 	# Node.js v16.0 is first version not supporting Python 2.7 but supports Python 3.6 ~ 3.9 so Python 3.9 is chosen
 }
 
 setGCC() {
-	if [ "$MAJOR_VERSION" -ge 22 ]; then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
-	if [ "$MAJOR_VERSION" -ge 8  ]; then source /opt/rh/devtoolset-9/enable;  return;  fi  # GCC 9.3:   Node.js v7.10 ~ v21.7 (latest)  (v20.0~v21.7 has compatibility warning by Node.js)
-	                                                                                       # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
+	if isNodeVersionGE 'v22.3';  then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
+	if isNodeVersionGE 'v7.10';  then source /opt/rh/devtoolset-9/enable;  return;  fi  # GCC 9.3:   Node.js v7.10 ~ v21.7 (latest)  (v20.0~v21.7 has compatibility warning by Node.js)
+	                                                                                    # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
 	
 	# Node.js v22.0 is first version not supporting GCC 9.3 but supports GCC 12.4- so GCC 12.4
 	# should be chosen, but support of v22.0~v22.2 is dropped and GCC 15.1 is chosen instead

--- a/recipes/x86/run_versions.sh
+++ b/recipes/x86/run_versions.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eux
+
+setPython() {
+	if [ "$MAJOR_VERSION" -ge 23 ]; then export PYTHON='python3.13';  return;  fi  # Python 3.13: Node.js v22.3  ~ latest (v24.3)
+	if [ "$MAJOR_VERSION" -ge 15 ]; then export PYTHON='python3.9';   return;  fi  # Python 3.9:  Node.js v14.14 ~ latest (v24.3)
+	if [ "$MAJOR_VERSION" -ge 4  ]; then export PYTHON='python2.7';   return;  fi  # Python 2.7:  Node.js v4.0   ~ v15.14 (latest)
+	
+	# Node.js v16.0 is first version not supporting Python 2.7 but supports Python 3.6 ~ 3.9 so Python 3.9 is chosen
+}
+
+setGCC() {
+	if [ "$MAJOR_VERSION" -ge 22 ]; then source /opt/gcc15/enable;            return;  fi  # GCC 15.1:  Node.js v22.3 ~ latest (v24.3)  (v22.3~v22.17 has more compilation warnings)
+	if [ "$MAJOR_VERSION" -ge 8  ]; then source /opt/rh/devtoolset-9/enable;  return;  fi  # GCC 9.3:   Node.js v7.10 ~ v21.7 (latest)  (v20.0~v21.7 has compatibility warning by Node.js)
+	                                                                                       # GCC 4.8.5: Node.js v4.0  ~ v10.14          (v9.0~v10.2 have compatibility warning by Node.js)
+	
+	# Node.js v22.0 is first version not supporting GCC 9.3 but supports GCC 12.4- so GCC 12.4
+	# should be chosen, but support of v22.0~v22.2 is dropped and GCC 15.1 is chosen instead
+}

--- a/recipes/x86/should-build.sh
+++ b/recipes/x86/should-build.sh
@@ -3,10 +3,14 @@
 __dirname=$1
 fullversion=$2
 
-. ${__dirname}/_decode_version.sh
+isNodeVersionGE() {
+	printf "$1\n$fullversion" | sort -VC
+}
 
-decode "$fullversion"
+isNodeVersionLT() {
+	! printf "$1\n$fullversion" | sort -VC
+}
 
-[ "$major" -ge 7 ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )  # Node.js v6.1- cannot download required files due to broken links
+isNodeVersionGE 'v6.2'                                      # Node.js v6.1- cannot download required files due to broken links
 
-[[ ! "$fullversion" =~ ^v22\.[0-2]\. ]]                             # GCC version between 9.3 and 15.1 is required but not installed
+! ( isNodeVersionGE 'v22.0'  && isNodeVersionLT 'v22.3'  )  # GCC version between 9.3 and 15.1 is required but not installed

--- a/recipes/x86/should-build.sh
+++ b/recipes/x86/should-build.sh
@@ -7,4 +7,5 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -lt "22"
+[ "$major" -ge 7 ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )
+[[ ! "$fullversion" =~ ^v22\.[0-2]\. ]]

--- a/recipes/x86/should-build.sh
+++ b/recipes/x86/should-build.sh
@@ -8,4 +8,5 @@ fullversion=$2
 decode "$fullversion"
 
 [ "$major" -ge 7 ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )  # Node.js v6.1- cannot download required files due to broken links
+
 [[ ! "$fullversion" =~ ^v22\.[0-2]\. ]]                             # GCC version between 9.3 and 15.1 is required but not installed

--- a/recipes/x86/should-build.sh
+++ b/recipes/x86/should-build.sh
@@ -8,4 +8,4 @@ fullversion=$2
 decode "$fullversion"
 
 [ "$major" -ge 7 ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )  # Node.js v6.1- cannot download required files due to broken links
-[[ ! "$fullversion" =~ ^v22\.[0-2]\. ]]                             # Not supported neigher by GCC 15.1 nor GCC 9.3 (GCC 12.4 would be good but is not installed)
+[[ ! "$fullversion" =~ ^v22\.[0-2]\. ]]                             # GCC version between 9.3 and 15.1 is required but not installed

--- a/recipes/x86/should-build.sh
+++ b/recipes/x86/should-build.sh
@@ -11,6 +11,6 @@ isNodeVersionLT() {
 	! printf "$1\n$fullversion" | sort -VC
 }
 
-isNodeVersionGE 'v6.2'                                      # Node.js v6.1- cannot download required files due to broken links
+isNodeVersionGE 'v6.2'                                # Node.js v6.1- cannot download required files due to broken links
 
-! ( isNodeVersionGE 'v22.0'  && isNodeVersionLT 'v22.3'  )  # GCC version between 9.3 and 15.1 is required but not installed
+isNodeVersionLT 'v22.0'  || isNodeVersionGE 'v22.3'   # Node.js v22.0~v22.2 requires GCC version between 9.3 and 15.1 which is not installed

--- a/recipes/x86/should-build.sh
+++ b/recipes/x86/should-build.sh
@@ -7,5 +7,5 @@ fullversion=$2
 
 decode "$fullversion"
 
-[ "$major" -ge 7 ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )
-[[ ! "$fullversion" =~ ^v22\.[0-2]\. ]]
+[ "$major" -ge 7 ] || ( [ "$major" -eq 6 ] && [ "$minor" -ge 2 ] )  # Node.js v6.1- cannot download required files due to broken links
+[[ ! "$fullversion" =~ ^v22\.[0-2]\. ]]                             # Not supported neigher by GCC 15.1 nor GCC 9.3 (GCC 12.4 would be good but is not installed)


### PR DESCRIPTION
## Description

This pull request adds compilation of Python, GCC and binutils (when needed).

## Added time for compilation (6 cores @ ~3.2+ GHz)

Added time:
   * Python 3.9.23:  43  | 76  sec  (added to compile older versions of Node.js)
   * Python 3.13.5:  41  | 86  sec  (added because it may become needed in the future)
   * GCC 15.1.0:     450 | 852 sec

Comments:
   * First number is the time of recompilation (accelerated with ccache)
   * Second number is the time of the first compilation
   * All numbers include downloading time
   * The x86 recipe theoretically should be slightly slower, but I didn't notice a difference

Other tests:
   * GCC 12.2.0:           289 | 637 sec
   * binutils-2.44:        37  | 75  sec  (binutils 2.35+ is required by Node.js v24.3.0)
   * installPrerequisites: 137       sec

## Reduced time of compilation (6 cores @ ~3.2+ GHz)

* Node.js v24.3.0:
   * First time:
      * 58 minutes (GCC 15.1.0)
      * Instead of 1 hour 55 minutes (GCC 12.1.1)

## Info

* Recipes are changed a lot (reviewing whole files is probably faster than comparing changes).
* 3 changed recipes are almost copies. To review the code see recipes/x64-glibc-217 and then run bin/copy-recipes.sh. This pull request changes 31 files but actually recipes/x64-glibc-217 contains only 9 files (~20 lines per file).
   * Shared Docker image is used to reduce required space and time. Probably these recipes are about 2 times faster than previous ones.
* FROM --platform=linux/386 centos:7 is used for x86 because V8 does not support x64→x86 compilation anymore (because emulator or scripts for snapshot creation are disabled for this pair). This image is not shared.
* Requirements:
   * Docker 23+ (2023)
   * Or Docker 18+ (2019) (execute "export DOCKER_BUILDKIT=1" before start)
   * 16 GB of RAM is recommended

## Tested on

My environment:
   * Intel (x64)
   * WSL 2
   * Debian 12
   * Docker 28.2.2

[Test results](https://github.com/nodejs/unofficial-builds/pull/174#issuecomment-3046144280)
