### PR TITLE
chore: stop building x64-glibc-217 on v24 until fixed

### DIFF
--- a/recipes/x64-glibc-217/should-build.sh
+++ b/recipes/x64-glibc-217/should-build.sh
@@ -7,4 +7,4 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "18"
+test "$major" -ge "18" && test "$major" -lt "24"


### PR DESCRIPTION
Python version problems
Ref: https://unofficial-builds.nodejs.org/logs/202507160208-v24.4.1/x64-glibc-217.log
Ref: https://github.com/nodejs/unofficial-builds/issues/176