### PR TITLE
chore: disable loong64 for v24 due to outdated python

### DIFF
--- a/recipes/loong64/should-build.sh
+++ b/recipes/loong64/should-build.sh
@@ -11,4 +11,4 @@ decode "$fullversion"
 (test "$major" -eq "20" && test "$minor" -ge "10") || \
 (test "$major" -eq "21") || \
 (test "$major" -eq "22" && test "$minor" -ge "14") || \
-(test "$major" -ge "23")
+(test "$major" -eq "23")


### PR DESCRIPTION
Ref: https://unofficial-builds.nodejs.org/logs/202507290214-v24.4.1/loong64.log
Ref: https://github.com/nodejs/unofficial-builds/issues/176