### PR TITLE
chore: disable armv6l on v24

### DIFF
--- a/recipes/armv6l/should-build.sh
+++ b/recipes/armv6l/should-build.sh
@@ -7,4 +7,4 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "16"
+test "$major" -ge "16" && test "$major" -lt "24"


### PR DESCRIPTION
Ref: https://unofficial-builds.nodejs.org/logs/202507290229-v24.4.1/armv6l.log
Ref: https://github.com/nodejs/unofficial-builds/pull/170