### PR TITLE
chore: disable x64-debug

### DIFF
--- a/recipes/x64-debug/should-build.sh
+++ b/recipes/x64-debug/should-build.sh
@@ -7,4 +7,4 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "18"
+test "$major" -ge "18" && test "$major" -lt "24"


### PR DESCRIPTION
Ref: https://unofficial-builds.nodejs.org/logs/202507290341-v24.4.1/x64-debug.log

C++ version problem? Needs someone to look and fix the recipe. Disabling for now.