### PR TITLE
Fix Loong64

### DIFF
--- a/recipes/loong64/Dockerfile
+++ b/recipes/loong64/Dockerfile
@@ -23,7 +23,10 @@ RUN apt-get update \
          gcc-14-loongarch64-linux-gnu
 
 RUN addgroup --gid $GID node \
-    && adduser --gid $GID --uid $UID --disabled-password --gecos node node
+    || groupmod -n node ubuntu
+
+RUN adduser --gid $GID --uid $UID --disabled-password --gecos node node \
+    || usermod -l node ubuntu
 
 RUN rm -f /usr/bin/python3
 RUN ln -s /usr/bin/python3.10 /usr/bin/python3

--- a/recipes/loong64/run.sh
+++ b/recipes/loong64/run.sh
@@ -22,6 +22,7 @@ export CC_host="ccache gcc-13"
 export CXX_host="ccache g++-13"
 export CC="ccache /usr/bin/loongarch64-linux-gnu-gcc-14"
 export CXX="ccache /usr/bin/loongarch64-linux-gnu-g++-14"
+export PYTHON="python3.10"
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="loong64" \

--- a/recipes/loong64/run.sh
+++ b/recipes/loong64/run.sh
@@ -22,7 +22,6 @@ export CC_host="ccache gcc-13"
 export CXX_host="ccache g++-13"
 export CC="ccache /usr/bin/loongarch64-linux-gnu-gcc-14"
 export CXX="ccache /usr/bin/loongarch64-linux-gnu-g++-14"
-export PYTHON="python3.10"
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="loong64" \

--- a/recipes/loong64/should-build.sh
+++ b/recipes/loong64/should-build.sh
@@ -11,4 +11,4 @@ decode "$fullversion"
 (test "$major" -eq "20" && test "$minor" -ge "10") || \
 (test "$major" -eq "21") || \
 (test "$major" -eq "22" && test "$minor" -ge "14") || \
-(test "$major" -eq "23")
+(test "$major" -ge "23")


### PR DESCRIPTION
I guess the server is just not updated with this repository (the files in the repository are probably newer) so we get python error (#176) because older version is running.

But commands addgroup and adduser have become broken in new version anyway.
This pull request fixes it and makes the recipe work again.