### PR TITLE
[loong64] Fixed the "The GID `1000' is already in use" error.

### DIFF
--- a/recipes/loong64/Dockerfile
+++ b/recipes/loong64/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update \
          gcc-14-loongarch64-linux-gnu-base \
          gcc-14-loongarch64-linux-gnu
 
-RUN addgroup --gid $GID node \
-    && adduser --gid $GID --uid $UID --disabled-password --gecos node node
+RUN (addgroup --gid $GID node || groupmod -n node $(getent group $GID | cut -d: -f1)) \
+    && (adduser --gid $GID --uid $UID --disabled-password --gecos "" node || usermod -l node -g $GID -d /home/node -m $(getent passwd $UID | cut -d: -f1))
 
 RUN rm -f /usr/bin/python3
 RUN ln -s /usr/bin/python3.10 /usr/bin/python3

--- a/recipes/loong64/should-build.sh
+++ b/recipes/loong64/should-build.sh
@@ -7,8 +7,7 @@ fullversion=$2
 
 decode "$fullversion"
 
-(test "$major" -eq "18" && test "$minor" -ge "18") || \
 (test "$major" -eq "20" && test "$minor" -ge "10") || \
 (test "$major" -eq "21") || \
 (test "$major" -eq "22" && test "$minor" -ge "14") || \
-(test "$major" -eq "23")
+(test "$major" -ge "23")


### PR DESCRIPTION
If the group/user with the specified GID/UID already exists, it will be changed to node:node.
similar to **recipes/riscv64/Dockerfile.**

Reopened builds for node versions >= 23.
Since simdutf has not been updated to version 6.2.1 or higher, building for version 18 has been disabled.