### PR TITLE
Fix Loong64 GLIBCXX version errors by statically linking libstdc++

### DIFF
--- a/recipes/loong64/run.sh
+++ b/recipes/loong64/run.sh
@@ -11,7 +11,7 @@ commit="$5"
 fullversion="$6"
 source_url="$7"
 source_urlbase="$8"
-config_flags="--openssl-no-asm"
+config_flags="--openssl-no-asm --partly-static"
 
 cd /home/node
 


### PR DESCRIPTION
## Description:
This PR addresses the GLIBCXX version compatibility issues reported in:
#187 
 https://github.com/nodejs/unofficial-builds/issues/176#issuecomment-3152149432

The cross-compiled Node.js binaries for Loong64 were failing at runtime with errors like:
```
[root@6986da0ddce7 /]# ./node-v24.7.0-linux-loong64/bin/node -v
./node-v24.7.0-linux-loong64/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.31' not found (required by ./node-v24.7.0-linux-loong64/bin/node)
./node-v24.7.0-linux-loong64/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by ./node-v24.7.0-linux-loong64/bin/node)
[root@6986da0ddce7 /]# strings /lib64/libstdc++.so.6 | grep GLIBCXX_
GLIBCXX_3.4
GLIBCXX_3.4.1
GLIBCXX_3.4.2
GLIBCXX_3.4.3
GLIBCXX_3.4.4
GLIBCXX_3.4.5
GLIBCXX_3.4.6
GLIBCXX_3.4.7
GLIBCXX_3.4.8
GLIBCXX_3.4.9
GLIBCXX_3.4.10
GLIBCXX_3.4.11
GLIBCXX_3.4.12
GLIBCXX_3.4.13
GLIBCXX_3.4.14
GLIBCXX_3.4.15
GLIBCXX_3.4.16
GLIBCXX_3.4.17
GLIBCXX_3.4.18
GLIBCXX_3.4.19
GLIBCXX_3.4.20
GLIBCXX_3.4.21
GLIBCXX_3.4.22
GLIBCXX_3.4.23
GLIBCXX_3.4.24
GLIBCXX_3.4.25
GLIBCXX_3.4.26
GLIBCXX_3.4.27
GLIBCXX_3.4.28
GLIBCXX_3.4.29
GLIBCXX_3.4.30
GLIBCXX_DEBUG_MESSAGE_LENGTH

```
## Solution:
Added export LDFLAGS="-static-libstdc++" to recipes/loong64/run.sh to statically link the libstdc++ library during compilation. 
This fixes the runtime error where the cross-compiled Node.js  binary for Loong64 fails to find required GLIBCXX versions.
