### PR TITLE
fix(x64-glibc-217): use modern gcc and python from conda-forge

### DIFF
--- a/recipes/x64-glibc-217/Dockerfile
+++ b/recipes/x64-glibc-217/Dockerfile
@@ -25,12 +25,12 @@ VOLUME /home/node/node.tar.xz
 
 USER node
 
-RUN cd "/home/node" && curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh \
-    && bash Miniforge3-Linux-x86_64.sh -b \
-    && rm Miniforge3-Linux-x86_64.sh
-ENV PATH="/home/node/miniforge3/bin:${PATH}"
-RUN mamba install -y \
-    python=3.12 \
-    gxx=15
+ENV PATH="/home/node/.local/bin:${PATH}"
+
+RUN curl -L micro.mamba.pm/install.sh | bash -s -- -y \
+    && eval "$(micromamba shell hook --shell bash)" \
+    && micromamba install -y \
+         python=3.12 \
+         gxx=15
 
 ENTRYPOINT [ "/home/node/run.sh" ]

--- a/recipes/x64-glibc-217/Dockerfile
+++ b/recipes/x64-glibc-217/Dockerfile
@@ -6,32 +6,16 @@ ARG UID=1000
 RUN groupadd --gid $GID node \
     && adduser --gid $GID --uid $UID node
 
-RUN cat <<EOF | tee -a /etc/yum.repos.d/devtoolset-12.repo
-[devtoolset-12]
-name=Devtoolset 12
-baseurl=https://buildlogs.centos.org/c7-devtoolset-12.x86_64/
-enabled=1
-gpgcheck=0
-EOF
-
 RUN ulimit -n 1024 \
     && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
     && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
     && yum install -y epel-release \
-    && yum install -y centos-release-scl-rh \
-    && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
-    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo \
     && yum upgrade -y \
     && yum install -y \
          git \
          curl \
          make \
-         python2 \
-         rh-python38 \
-         ccache \
-         xz-utils \
-         devtoolset-12 \
-         glibc-devel
+         ccache
 
 COPY --chown=node:node run.sh /home/node/run.sh
 
@@ -40,5 +24,13 @@ VOLUME /out
 VOLUME /home/node/node.tar.xz
 
 USER node
+
+RUN cd "/home/node" && curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh \
+    && bash Miniforge3-Linux-x86_64.sh -b \
+    && rm Miniforge3-Linux-x86_64.sh
+ENV PATH="/home/node/miniforge3/bin:${PATH}"
+RUN mamba install -y \
+    python=3.12 \
+    gxx=15
 
 ENTRYPOINT [ "/home/node/run.sh" ]

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -17,8 +17,10 @@ cd /home/node
 
 tar -xf node.tar.xz
 
+nodeDir="/home/node/node-${fullversion}"
+
 # configuring cares correctly to not use sys/random.h on this target
-cd "node-${fullversion}"/deps/cares
+cd "${nodeDir}"/deps/cares
 sed -i 's/define HAVE_SYS_RANDOM_H 1/undef HAVE_SYS_RANDOM_H/g' ./config/linux/ares_config.h
 sed -i 's/define HAVE_GETRANDOM 1/undef HAVE_GETRANDOM/g' ./config/linux/ares_config.h
 
@@ -27,16 +29,15 @@ if [[ "$(grep -o 'ARES_VERSION_STR "[^"]*"' ./include/ares_version.h | awk '{pri
   sed -i 's/MSG_FASTOPEN/TCP_FASTOPEN_CONNECT/g' ./src/lib/ares__socket.c
 fi
 
-cd /home/node
+# Linux implementation of experimental WASM memory control requires Linux 3.17 & glibc 2.27 so disable it
+cd "${nodeDir}"/deps/v8/src
+[ -f d8/d8.cc ] && sed -i -e 's/#if V8_TARGET_OS_LINUX/#if false/g' wasm/wasm-objects.cc d8/d8.cc
 
-cd "node-${fullversion}"
+cd "${nodeDir}"
 
 export CC="ccache gcc"
 export CXX="ccache g++"
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)
-
-. /opt/rh/devtoolset-12/enable
-. /opt/rh/rh-python38/enable
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="x64" \

--- a/recipes/x64-glibc-217/run.sh
+++ b/recipes/x64-glibc-217/run.sh
@@ -35,6 +35,9 @@ cd "${nodeDir}"/deps/v8/src
 
 cd "${nodeDir}"
 
+eval "$(micromamba shell hook --shell bash)"
+micromamba activate
+
 export CC="ccache gcc"
 export CXX="ccache g++"
 export MAJOR_VERSION=$(echo ${fullversion} | cut -d . -f 1 | tr --delete v)

--- a/recipes/x64-glibc-217/should-build.sh
+++ b/recipes/x64-glibc-217/should-build.sh
@@ -7,4 +7,4 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "18" && test "$major" -lt "24"
+test "$major" -ge "18"


### PR DESCRIPTION
@vitaliylag made really awesome job in #174 !
I like most of the changes, but building gcc and several versions of python looks a bit overkill.

I'm creating this to show another more straightforward way to get modern gcc and python even on centos:7

My main need is modern nodejs on the legacy el7, so I fixed x64-glibc-217 only.  
But it looks like we can use just the same docker image for all centos:7-based recipes.

I assume that modern gcc and python can build old nodejs versions also.  
Moreover, we already have them in the repo, so who cares to rebuild them once again.
But if we really want to use different gcc and python versions for previous nodejs builds, we can do that gracefully with conda/mamba:

```
mamba create -n 'v8.0' gxx=12
mamba create -n 'v14.14' gxx=12 python=3.9
mamba create -n 'v22.3' gxx=15 python=3.13
```

and then just switch them as
```
mamba activate 'v22.3'
```