### PR TITLE
Bump dist-indexer version to support the last new unofficial builds

### DIFF
--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -17,7 +17,7 @@ recipes=(
 # This should be updated as new versions of nodejs-dist-indexer are released to
 # include new assets published here; this is not done automatically for security
 # reasons.
-dist_indexer_version=v1.7.1
+dist_indexer_version=v1.7.26
 
 image_tag_pfx=unofficial-build-recipe-
 


### PR DESCRIPTION
Summary:

* linux-arm64-musl support was added in https://github.com/nodejs/unofficial-builds/pull/189
* linux-arm64-musl awareness was added in https://github.com/nodejs/nodejs-dist-indexer/pull/63

This PR adds a version of the dist-indexer that supports the linux-arm64-musl releases

More context in https://github.com/nodejs/unofficial-builds/pull/189#issuecomment-3591938937 and https://github.com/nodejs/nodejs-dist-indexer/pull/63
