### PR TITLE
chore: enable riscv64 builds for versions 22, 23 and 25

### DIFF
--- a/recipes/riscv64/should-build.sh
+++ b/recipes/riscv64/should-build.sh
@@ -7,4 +7,4 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "17" && test "$major" -lt "22"
+test "$major" -ge "17" && test "$major" -ne "24" && test "$major" -ne 26


### PR DESCRIPTION
I've successfully built node 22 and 23 using the cross compiler.
Node 24+ still has problems (although builds natively)

Noting that for the successful cross-compiler tests of node 22 and 23 I was using a container created with `CC_host` pointing at gcc_14 instead of the default 13 for the recipe (cross-compiler was 14 in both cases) but I don't think that will be relevant. I initially switched when testing 24, which failed regardless.

Partial revert of https://github.com/nodejs/unofficial-builds/pull/155