### PR TITLE
chore: switch build order - popular first, dead last

### DIFF
--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -1,23 +1,28 @@
-# All of our build recipes, new recipes should be added here.
+# All of our build recipes, order matters: recipes run sequentially, so put the
+# most popular/important ones first. Recipes with a should-build.sh that gates
+# them out for a given version are skipped instantly.
 recipes=(
+  # Active recipes, ordered by likely popularity
   "headers"
-  "x86"
   "musl"
-  "armv6l"
-  "x64-glibc-217"
-  "x64-pointer-compression"
-  "x64-usdt"
+  "arm64-musl"
   "riscv64"
   "loong64"
-  "x64-debug"
-  "arm64-musl"
+
+  # Legacy recipes, currently gated out for modern Node.js versions
+  "x86"                     # major < 22
+  "armv6l"                  # major < 24
+  "x64-glibc-217"           # major < 24
+  "x64-pointer-compression" # major < 23
+  "x64-debug"               # major < 24
+  "x64-usdt"                # major <= 18
 )
 
 
 # This should be updated as new versions of nodejs-dist-indexer are released to
 # include new assets published here; this is not done automatically for security
 # reasons.
-dist_indexer_version=v1.7.26
+dist_indexer_version=v1.7.30
 
 image_tag_pfx=unofficial-build-recipe-
 


### PR DESCRIPTION
I'm noticing two things: that we have a lot of dead recipes that we skip over and we could clean up slightly by putting them all last, but also that we have a few cross-compile builds that take a very long time and I don't think we're doing them in optimal order to get them out fast.