### PR TITLE
chore: re-add linux/riscv64 v24

### DIFF
--- a/recipes/riscv64/should-build.sh
+++ b/recipes/riscv64/should-build.sh
@@ -7,4 +7,4 @@ fullversion=$2
 
 decode "$fullversion"
 
-test "$major" -ge "17" && test "$major" -ne "24" && test "$major" -ne 26
+test "$major" -ge "17" && test "$major" -ne 26


### PR DESCRIPTION
With the cherry pick of https://github.com/nodejs/node/pull/60989 [landing in v24.13.1](https://nodejs.org/en/blog/release/v24.13.1#commits) this can be re-enabled.

Ref: https://github.com/nodejs/build/issues/4099