### PR TITLE
feat: add riscv64 clang build with pointer compression enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This list of officially supported platforms is available in the Node.js [BUILDIN
  * **linux-x64-pointer-compression**: Linux x64 binaries compiled with V8 pointer compression enabled (`--experimental-enable-pointer-compression`).
  * **linux-armv6l**: Linux ARMv6 binaries, cross-compiled on Ubuntu 22.04 with a [custom GCC 12 toolchain](https://github.com/rvagg/rpi-newer-crosstools). Binaries are optimized for `armv6zk` which is suitable for Raspberry Pi devices (1, 1+ and Zero in particular).
  * **linux-riscv64**: Linux RISC-V 64-bit, cross-compiled on Ubuntu 24.04 with GCC 14.
+ * **linux-riscv64-pointer-compression**: Linux RISC-V 64-bit, cross-compiled on Ubuntu 24.04 with clang-19 and  --experimental-pointer-compression enabled to reduce RAM usage.
  * **linux-loong64**: Linux LoongArch64, cross-compiled with the Loongson toolchain.
  * **linux-x86**: Linux x86 (32-bit) binaries compiled against libc 2.17. 32-bit Linux binaries were dropped for Node.js 10 and 32-bit support is now considered "Experimental".
  * **linux-x64-usdt**: Linux x64 binaries compiled with DTrace/USDT support.
@@ -56,6 +57,7 @@ Builds are published at <https://unofficial-builds.nodejs.org/download/release/>
 | linux-arm64-musl | All | Added in [#189] |
 | linux-loong64 | >= v23; also v20.10+, v21, v22.14+ | Toolchain upgraded in [#172] |
 | linux-riscv64 | >= v17 | Note: 26 will require [extra CXXFLAGS](https://github.com/nodejs/build/issues/4099#issuecomment-3619150119) |
+| linux-riscv64-pointer-compression | >= v22 | Built with clang instead of GCC ([#222]) |
 | linux-x64-glibc-217 | v18 - v23 | v24+: Python too old in CentOS 7 container ([#177], [#176]) |
 | linux-x64-debug | v18 - v23 | v24+: C++ compiler too old ([#180]) |
 | linux-x64-pointer-compression | v14 - v22 | v23+: CentOS 7 toolchain too old ([#155], [#158]) |
@@ -66,6 +68,7 @@ Builds are published at <https://unofficial-builds.nodejs.org/download/release/>
 [#155]: https://github.com/nodejs/unofficial-builds/pull/155
 [#158]: https://github.com/nodejs/unofficial-builds/pull/158
 [#172]: https://github.com/nodejs/unofficial-builds/pull/172
+[#222]: https://github.com/nodejs/unofficial-builds/pull/222
 [#176]: https://github.com/nodejs/unofficial-builds/issues/176
 [#177]: https://github.com/nodejs/unofficial-builds/pull/177
 [#179]: https://github.com/nodejs/unofficial-builds/pull/179

--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -8,6 +8,7 @@ recipes=(
   "arm64-musl"
   "riscv64"
   "loong64"
+  "riscv64-pointer-compression"
 
   # Legacy recipes, currently gated out for modern Node.js versions
   "x86"                     # major < 22

--- a/recipes/riscv64-pointer-compression/Dockerfile
+++ b/recipes/riscv64-pointer-compression/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:24.04
+
+ARG GID=1000
+ARG UID=1000
+
+RUN apt -y update && \
+    apt -y dist-upgrade && \
+    apt install -y \
+        clang-19 \
+        lld \
+        gcc-riscv64-linux-gnu \
+        g++-riscv64-linux-gnu \
+        ccache \
+        make \
+        git \
+        xz-utils \
+        adduser && \
+    apt install -y less file bzip2 curl adduser joe
+
+RUN (addgroup --gid $GID node || groupmod -n node $(getent group $GID | cut -d: -f1)) \
+    && (adduser --gid $GID --uid $UID --disabled-password --gecos "" node || usermod -l node -g $GID -d /home/node -m $(getent passwd $UID | cut -d: -f1))
+
+COPY --chown=node:node run.sh /home/node/run.sh
+
+VOLUME /home/node/.ccache
+VOLUME /out
+VOLUME /home/node/node.tar.xz
+
+USER node
+
+ ENTRYPOINT [ "/home/node/run.sh" ]

--- a/recipes/riscv64-pointer-compression/run.sh
+++ b/recipes/riscv64-pointer-compression/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+release_urlbase="$1"
+disttype="$2"
+customtag="$3"
+datestring="$4"
+commit="$5"
+fullversion="$6"
+source_url="$7"
+source_urlbase="$8"
+config_flags="--openssl-no-asm --use_clang --experimental-enable-pointer-compression"
+
+cd /home/node
+
+tar -xf node.tar.xz
+cd "node-${fullversion}"
+
+export CCACHE_BASEDIR="$PWD"
+export CC='ccache clang-19  --target=riscv64-linux-gnu -march=rv64gc'
+export CXX='ccache clang++-19  --target=riscv64-linux-gnu -march=rv64gc'
+export CC_host='ccache clang-19'
+export CXX_host='ccache clang++-19'
+
+#make -j$(getconf _NPROCESSORS_ONLN) binary \
+
+make -j4 binary \
+  DESTCPU="riscv64" \
+  ARCH="riscv64" \
+  VARIATION="" \
+  DISTTYPE="$disttype" \
+  CUSTOMTAG="$customtag" \
+  DATESTRING="$datestring" \
+  COMMIT="$commit" \
+  RELEASE_URLBASE="$release_urlbase" \
+  CONFIG_FLAGS="$config_flags"
+
+# If removal of ICU is desired, add "BUILD_INTL_FLAGS=--with-intl=none" above
+
+mv node-*.tar.?z /out/

--- a/recipes/riscv64-pointer-compression/should-build.sh
+++ b/recipes/riscv64-pointer-compression/should-build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -xe
+
+__dirname=$1
+fullversion=$2
+
+. ${__dirname}/_decode_version.sh
+
+decode "$fullversion"
+
+# v20 does not build successfully with clang19
+test "$major" -ge "22"


### PR DESCRIPTION
This serves two purposes:
- Trial clang cross-compile builds (Fixes https://github.com/nodejs/unofficial-builds/issues/217) - I've chosen to make this a separate recipe for now so that differences can be noted.
- Add the experimental pointer compression build option which should significantly reduce memory usage (Ref discussion in https://github.com/nodejs/admin/issues/1042#issuecomment-3922290263).

While I appreciate that this is two changes which could both introduce differences in behavior it seems the best way of having this testable and we can do one-off builds with one or the other as desired (Part of me wanted to skip ICU in this build too in order to reduce memory usage further but I've held off on that for now :-)

Using `clang` will also be a useful enhancement for Node 26 as all current GCC versions will not build correctly unless `-DHWY_BROKEN_EMU128=0` is specified (Ref: https://github.com/nodejs/build/issues/4099#issuecomment-3621326485)

FYI @nodejs/platform-riscv64 