### PR TITLE
feat: set VARIATION for rv64/pointer-compression to change tarball name

### DIFF
--- a/recipes/riscv64-pointer-compression/Dockerfile
+++ b/recipes/riscv64-pointer-compression/Dockerfile
@@ -28,4 +28,4 @@ VOLUME /home/node/node.tar.xz
 
 USER node
 
- ENTRYPOINT [ "/home/node/run.sh" ]
+ENTRYPOINT [ "/home/node/run.sh" ]

--- a/recipes/riscv64-pointer-compression/run.sh
+++ b/recipes/riscv64-pointer-compression/run.sh
@@ -24,9 +24,7 @@ export CXX='ccache clang++-19  --target=riscv64-linux-gnu -march=rv64gc'
 export CC_host='ccache clang-19'
 export CXX_host='ccache clang++-19'
 
-#make -j$(getconf _NPROCESSORS_ONLN) binary \
-
-make -j4 binary \
+make -j$(getconf _NPROCESSORS_ONLN) binary \
   DESTCPU="riscv64" \
   ARCH="riscv64" \
   VARIATION="pointer-compression" \

--- a/recipes/riscv64-pointer-compression/run.sh
+++ b/recipes/riscv64-pointer-compression/run.sh
@@ -29,7 +29,7 @@ export CXX_host='ccache clang++-19'
 make -j4 binary \
   DESTCPU="riscv64" \
   ARCH="riscv64" \
-  VARIATION="" \
+  VARIATION="pointer-compression" \
   DISTTYPE="$disttype" \
   CUSTOMTAG="$customtag" \
   DATESTRING="$datestring" \

--- a/recipes/riscv64-pointer-compression/run.sh
+++ b/recipes/riscv64-pointer-compression/run.sh
@@ -24,7 +24,7 @@ export CXX='ccache clang++-19  --target=riscv64-linux-gnu -march=rv64gc'
 export CC_host='ccache clang-19'
 export CXX_host='ccache clang++-19'
 
-make -j$(getconf _NPROCESSORS_ONLN) binary \
+make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="riscv64" \
   ARCH="riscv64" \
   VARIATION="pointer-compression" \


### PR DESCRIPTION
VARIATION wasn't configured in the original code which means that the tarball comes out as the same as the gcc/non-compressed version and so overwrites it. I wrongly expected that it would use the name of recipe. This change should force the alternate tarball name as is done for the x64-pointer-compression version. (A couple of other minor corrections included too)