### PR TITLE
Add rust+cargo to musl toolchain

### DIFF
--- a/recipes/musl/Dockerfile
+++ b/recipes/musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23
+FROM alpine:3.22
 
 ARG GID=1000
 ARG UID=1000

--- a/recipes/musl/Dockerfile
+++ b/recipes/musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.23
 
 ARG GID=1000
 ARG UID=1000

--- a/recipes/musl/Dockerfile
+++ b/recipes/musl/Dockerfile
@@ -20,7 +20,9 @@ RUN apk add --no-cache \
         make \
         python3 \
         ccache \
-        xz
+        xz \
+        rust \
+        cargo
 
 COPY --chown=node:node run.sh /home/node/run.sh
 


### PR DESCRIPTION
See #227
See https://github.com/nodejs/docker-node/issues/2486

This probably affects all architectures that are built here. 

The only one that is used in the official docker images seems to be x64:
https://github.com/nodejs/docker-node/commit/6027bae61ff1156345f00a05a814cdb1fdd17f0d

Merging this would prevent the new docker images from being blocked. We probably can fix the cross-compilation later.