### PR TITLE
fix: emit build-id in arm64-musl cross-compiled binaries

### DIFF
--- a/recipes/arm64-musl/run.sh
+++ b/recipes/arm64-musl/run.sh
@@ -22,6 +22,13 @@ export CC_host="ccache gcc"
 export CXX_host="ccache g++"
 export CC="ccache /opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc"
 export CXX="ccache /opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-g++ -static-libstdc++"
+# The musl-cross-make-built toolchain has no specs file injecting
+# -Wl,--build-id like distro-packaged cross-compilers do, so without this the
+# resulting binary has no .note.gnu.build-id section and no PT_NOTE program
+# header. That breaks postject-based SEA tooling, which relies on
+# dl_iterate_phdr finding a PT_NOTE segment to extend.
+# Refs: https://github.com/nodejs/unofficial-builds/issues/200
+export LDFLAGS="-Wl,--build-id=sha1"
 
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="arm64" \


### PR DESCRIPTION
## Summary

The musl-cross-make toolchain used for arm64-musl has no specs file injecting `-Wl,--build-id`, unlike the distro-packaged cross-compilers used for `loong64`/`riscv64` or the native gcc used for `x64-musl`. As a result, the resulting binary has no `.note.gnu.build-id` section and **no `PT_NOTE` program header at all**, which breaks postject-based SEA tooling (`dl_iterate_phdr` finds no notes → `postject_find_resource()` returns NULL → `BlobDeserializer::ReadArithmetic` SEGVs).

Adding `LDFLAGS="-Wl,--build-id=sha1"` to `recipes/arm64-musl/run.sh` restores parity with every other recipe's output and unblocks SEA on the unofficial arm64-musl tarball.

## Why this is the right place to fix it

| Recipe | Cross-compiler source | Emits `PT_NOTE` today? |
|---|---|---|
| `arm64-musl` | Self-built `richfelker/musl-cross-make` (commit `3635262`) | ❌ No |
| `loong64` | Ubuntu's `g++-14-loongarch64-linux-gnu` package | ✅ Yes |
| `riscv64` / `riscv64-pointer-compression` | Ubuntu's `g++-14-riscv64-linux-gnu` package | ✅ Yes |
| `musl` (x64-musl) | Alpine's native `g++` | ✅ Yes |

Only `arm64-musl` is affected. The PR is intentionally a one-line LDFLAGS addition rather than re-configuring the musl-cross-make binutils build, to minimize blast radius.

## Refs

Closes nodejs/unofficial-builds#200.

Full root-cause analysis in https://github.com/nodejs/unofficial-builds/issues/200#issuecomment-4501013580 and https://github.com/nodejs/unofficial-builds/issues/200#issuecomment-4502555778.

## Test plan

- [ ] CI: build `arm64-musl` on `unofficial-builds.nodejs.org`
- [ ] `readelf -lW node | grep '^\s*NOTE'` on the resulting binary should show a `NOTE` program header
- [ ] `readelf -SW node | grep '\.note'` should show `.note.gnu.build-id`
- [ ] End-to-end SEA on Apple Silicon / arm64 Linux: `node --experimental-sea-config ... && cp $(which node) hello && npx postject hello NODE_SEA_BLOB sea-prep.blob --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 && ./hello` should print the embedded JS instead of segfaulting

I haven't been able to validate locally (musl-cross-make toolchain build ~30 min + Node build ~1–2 hr on my hardware); the fix is well-supported by the diagnosis but needs a CI run on this repo's infrastructure to confirm.