### PR TITLE
arm64-musl: add rust and cargo to the build dependencies

### DIFF
--- a/recipes/arm64-musl/Dockerfile
+++ b/recipes/arm64-musl/Dockerfile
@@ -22,11 +22,6 @@ RUN apk add --no-cache \
         ccache \
         xz \
         patch \
-        # rustc/cargo are needed for the Temporal API support in Node 26+
-        # (the build silently skips Temporal when they are not in PATH).
-        # Pinned so the rust-std target download below matches.
-        rust=1.91.1-r2 \
-        cargo=1.91.1-r2 \
         # extra packages required for creating the musl based cross-compiler
         rsync make gcc g++ bzip2 git
 
@@ -51,26 +46,37 @@ RUN RELEASE="3635262e4524c991552789af6f36211a335a77b3" && \
     cd / && \
     rm -rf /musl-cross-make-${RELEASE}/ ${RELEASE}.tar.gz
 
-# Install the aarch64-unknown-linux-musl Rust std library for cross-compiling.
-# Alpine's `rust` package only ships the host (x86_64-musl) standard library;
-# building `cargo --target=aarch64-unknown-linux-musl` requires a matching
-# std artifact under `/usr/lib/rustlib/`. Pull the prebuilt std from the
-# upstream Rust dist server, matching the version of the host toolchain.
-# Hash verified against the publisher's signed sha256 manifest at
-# https://static.rust-lang.org/dist/rust-std-1.91.1-aarch64-unknown-linux-musl.tar.xz.sha256
+# Rust for the Temporal API in Node 26+ (the build silently skips Temporal
+# when rustc/cargo are not in PATH). The host toolchain and the
+# aarch64-unknown-linux-musl target std must come from the same build of
+# rustc (E0514 rejects mixed rlibs), so both come from the upstream dist
+# server rather than Alpine's own rustc build, which cannot consume upstream
+# std rlibs. Hashes verified against the publisher's manifests, e.g.
+# https://static.rust-lang.org/dist/rust-1.91.1-x86_64-unknown-linux-musl.tar.xz.sha256
 # Approach based on nikeee's commit in
 # https://github.com/nodejs/unofficial-builds/commit/74ae38b3117b8dc29f6f2f00e37205cbe447e167
-RUN RUST_STD_VERSION="1.91.1" && \
+RUN RUST_VERSION="1.91.1" && \
+    RUST_HOST_SHA256="2fc7cac1663d245530bca0d487b2423f6b5a0bb99f03eedc439a155484dd6f56" && \
     RUST_STD_SHA256="2a919a0e5df46e1bfe4b8be8fbc81cf48bf9813be34ff5f212a2a68f03eb517f" && \
-    wget -O /tmp/rust-std.tar.xz \
-        "https://static.rust-lang.org/dist/rust-std-${RUST_STD_VERSION}-aarch64-unknown-linux-musl.tar.xz" && \
-    echo "${RUST_STD_SHA256}  /tmp/rust-std.tar.xz" | sha256sum -c - && \
-    # busybox tar's built-in xz decoder cannot read this archive; use the
+    wget -O /tmp/rust-host.tar.xz \
+        "https://static.rust-lang.org/dist/rust-${RUST_VERSION}-x86_64-unknown-linux-musl.tar.xz" && \
+    echo "${RUST_HOST_SHA256}  /tmp/rust-host.tar.xz" | sha256sum -c - && \
+    # busybox tar's built-in xz decoder cannot read these archives; use the
     # real xz installed above
+    xz -dc /tmp/rust-host.tar.xz | tar -x -C /tmp && \
+    /tmp/rust-${RUST_VERSION}-x86_64-unknown-linux-musl/install.sh --prefix=/opt/rust \
+        --components=rustc,cargo,rust-std-x86_64-unknown-linux-musl --disable-ldconfig && \
+    wget -O /tmp/rust-std.tar.xz \
+        "https://static.rust-lang.org/dist/rust-std-${RUST_VERSION}-aarch64-unknown-linux-musl.tar.xz" && \
+    echo "${RUST_STD_SHA256}  /tmp/rust-std.tar.xz" | sha256sum -c - && \
     xz -dc /tmp/rust-std.tar.xz | tar -x -C /tmp && \
-    cp -r /tmp/rust-std-${RUST_STD_VERSION}-aarch64-unknown-linux-musl/rust-std-aarch64-unknown-linux-musl/lib/rustlib/aarch64-unknown-linux-musl \
-        /usr/lib/rustlib/ && \
-    rm -rf /tmp/rust-std*
+    /tmp/rust-std-${RUST_VERSION}-aarch64-unknown-linux-musl/install.sh --prefix=/opt/rust --disable-ldconfig && \
+    rm -rf /tmp/rust-*
+
+# node's gyp invokes plain `cargo` for host and cross builds alike; this shim
+# (found first in PATH) adds --target for the cross target only
+COPY --chmod=755 cargo-shim.sh /usr/local/bin/cargo
+RUN ln -s /opt/rust/bin/rustc /usr/local/bin/rustc
 
 # Tell Cargo to use the musl-cross-make linker when targeting aarch64-musl.
 COPY <<-EOF /usr/local/cargo/config.toml

--- a/recipes/arm64-musl/Dockerfile
+++ b/recipes/arm64-musl/Dockerfile
@@ -22,7 +22,11 @@ RUN apk add --no-cache \
         ccache \
         xz \
         patch \
-        # extra packages required for creating the musl based cross-compiler 
+        # rustc/cargo are needed for the Temporal API support in Node 26+
+        # (build silently skips Temporal when they are not in PATH)
+        rust \
+        cargo \
+        # extra packages required for creating the musl based cross-compiler
         rsync make gcc g++ bzip2 git
 
 COPY <<-EOF /config/config.mak

--- a/recipes/arm64-musl/Dockerfile
+++ b/recipes/arm64-musl/Dockerfile
@@ -25,8 +25,8 @@ RUN apk add --no-cache \
         # rustc/cargo are needed for the Temporal API support in Node 26+
         # (the build silently skips Temporal when they are not in PATH).
         # Pinned so the rust-std target download below matches.
-        rust=1.87.0-r1 \
-        cargo=1.87.0-r1 \
+        rust=1.91.1-r2 \
+        cargo=1.91.1-r2 \
         # extra packages required for creating the musl based cross-compiler
         rsync make gcc g++ bzip2 git
 
@@ -57,11 +57,11 @@ RUN RELEASE="3635262e4524c991552789af6f36211a335a77b3" && \
 # std artifact under `/usr/lib/rustlib/`. Pull the prebuilt std from the
 # upstream Rust dist server, matching the version of the host toolchain.
 # Hash verified against the publisher's signed sha256 manifest at
-# https://static.rust-lang.org/dist/rust-std-1.87.0-aarch64-unknown-linux-musl.tar.xz.sha256
+# https://static.rust-lang.org/dist/rust-std-1.91.1-aarch64-unknown-linux-musl.tar.xz.sha256
 # Approach based on nikeee's commit in
 # https://github.com/nodejs/unofficial-builds/commit/74ae38b3117b8dc29f6f2f00e37205cbe447e167
-RUN RUST_STD_VERSION="1.87.0" && \
-    RUST_STD_SHA256="15fd0652e2f3a8b678be8a83e396a1103fb1bb941afabe3fdaec706f3bdc85d0" && \
+RUN RUST_STD_VERSION="1.91.1" && \
+    RUST_STD_SHA256="2a919a0e5df46e1bfe4b8be8fbc81cf48bf9813be34ff5f212a2a68f03eb517f" && \
     wget -O /tmp/rust-std.tar.xz \
         "https://static.rust-lang.org/dist/rust-std-${RUST_STD_VERSION}-aarch64-unknown-linux-musl.tar.xz" && \
     echo "${RUST_STD_SHA256}  /tmp/rust-std.tar.xz" | sha256sum -c - && \

--- a/recipes/arm64-musl/Dockerfile
+++ b/recipes/arm64-musl/Dockerfile
@@ -23,9 +23,10 @@ RUN apk add --no-cache \
         xz \
         patch \
         # rustc/cargo are needed for the Temporal API support in Node 26+
-        # (build silently skips Temporal when they are not in PATH)
-        rust \
-        cargo \
+        # (the build silently skips Temporal when they are not in PATH).
+        # Pinned so the rust-std target download below matches.
+        rust=1.87.0-r1 \
+        cargo=1.87.0-r1 \
         # extra packages required for creating the musl based cross-compiler
         rsync make gcc g++ bzip2 git
 
@@ -49,6 +50,32 @@ RUN RELEASE="3635262e4524c991552789af6f36211a335a77b3" && \
     make -I /config install && \
     cd / && \
     rm -rf /musl-cross-make-${RELEASE}/ ${RELEASE}.tar.gz
+
+# Install the aarch64-unknown-linux-musl Rust std library for cross-compiling.
+# Alpine's `rust` package only ships the host (x86_64-musl) standard library;
+# building `cargo --target=aarch64-unknown-linux-musl` requires a matching
+# std artifact under `/usr/lib/rustlib/`. Pull the prebuilt std from the
+# upstream Rust dist server, matching the version of the host toolchain.
+# Hash verified against the publisher's signed sha256 manifest at
+# https://static.rust-lang.org/dist/rust-std-1.87.0-aarch64-unknown-linux-musl.tar.xz.sha256
+# Approach based on nikeee's commit in
+# https://github.com/nodejs/unofficial-builds/commit/74ae38b3117b8dc29f6f2f00e37205cbe447e167
+RUN RUST_STD_VERSION="1.87.0" && \
+    RUST_STD_SHA256="15fd0652e2f3a8b678be8a83e396a1103fb1bb941afabe3fdaec706f3bdc85d0" && \
+    wget -O /tmp/rust-std.tar.xz \
+        "https://static.rust-lang.org/dist/rust-std-${RUST_STD_VERSION}-aarch64-unknown-linux-musl.tar.xz" && \
+    echo "${RUST_STD_SHA256}  /tmp/rust-std.tar.xz" | sha256sum -c - && \
+    tar -xJf /tmp/rust-std.tar.xz -C /tmp && \
+    cp -r /tmp/rust-std-${RUST_STD_VERSION}-aarch64-unknown-linux-musl/rust-std-aarch64-unknown-linux-musl/lib/rustlib/aarch64-unknown-linux-musl \
+        /usr/lib/rustlib/ && \
+    rm -rf /tmp/rust-std*
+
+# Tell Cargo to use the musl-cross-make linker when targeting aarch64-musl.
+COPY <<-EOF /usr/local/cargo/config.toml
+  [target.aarch64-unknown-linux-musl]
+  linker = "/opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc"
+EOF
+ENV CARGO_HOME=/usr/local/cargo
 
 COPY --chown=node:node run.sh /home/node/run.sh
 

--- a/recipes/arm64-musl/Dockerfile
+++ b/recipes/arm64-musl/Dockerfile
@@ -65,7 +65,9 @@ RUN RUST_STD_VERSION="1.91.1" && \
     wget -O /tmp/rust-std.tar.xz \
         "https://static.rust-lang.org/dist/rust-std-${RUST_STD_VERSION}-aarch64-unknown-linux-musl.tar.xz" && \
     echo "${RUST_STD_SHA256}  /tmp/rust-std.tar.xz" | sha256sum -c - && \
-    tar -xJf /tmp/rust-std.tar.xz -C /tmp && \
+    # busybox tar's built-in xz decoder cannot read this archive; use the
+    # real xz installed above
+    xz -dc /tmp/rust-std.tar.xz | tar -x -C /tmp && \
     cp -r /tmp/rust-std-${RUST_STD_VERSION}-aarch64-unknown-linux-musl/rust-std-aarch64-unknown-linux-musl/lib/rustlib/aarch64-unknown-linux-musl \
         /usr/lib/rustlib/ && \
     rm -rf /tmp/rust-std*

--- a/recipes/arm64-musl/cargo-shim.sh
+++ b/recipes/arm64-musl/cargo-shim.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Node's gyp runs one shared cargo action for both toolsets, but mksnapshot
+# (host) and node (target) each need their own architecture's crates. Build
+# both triples; run.sh patches crates.gyp to point each toolset at its own.
+# Upstream does per-platform target selection for Windows in
+# deps/crates/cargo_build.py; Linux cross-compilation has no equivalent yet.
+set -e
+
+HOST_TRIPLE=x86_64-unknown-linux-musl
+CROSS_TRIPLE=aarch64-unknown-linux-musl
+CARGO=/opt/rust/bin/cargo
+export PATH="/opt/rust/bin:$PATH"
+
+targetdir=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--target-dir" ]; then
+    targetdir="$arg"
+  fi
+  prev="$arg"
+done
+
+# only gyp's build invocations pass --target-dir; everything else (e.g.
+# `cargo --version` from node's configure) passes through untouched
+if [ -z "$targetdir" ]; then
+  exec "$CARGO" "$@"
+fi
+
+"$CARGO" "$@" --target "$HOST_TRIPLE"
+"$CARGO" "$@" --target "$CROSS_TRIPLE"
+
+# gyp's action output is the triple-less path; satisfy its freshness check
+if [ -n "$targetdir" ]; then
+  for profile in release debug; do
+    if [ -f "${targetdir}/${CROSS_TRIPLE}/${profile}/libnode_crates.a" ]; then
+      mkdir -p "${targetdir}/${profile}"
+      cp "${targetdir}/${CROSS_TRIPLE}/${profile}/libnode_crates.a" "${targetdir}/${profile}/"
+    fi
+  done
+fi

--- a/recipes/arm64-musl/run.sh
+++ b/recipes/arm64-musl/run.sh
@@ -30,6 +30,39 @@ export CXX="ccache /opt/aarch64-linux-musl-cross/bin/aarch64-linux-musl-g++ -sta
 # Refs: https://github.com/nodejs/unofficial-builds/issues/200
 export LDFLAGS="-Wl,--build-id=sha1"
 
+# Temporal needs the rust toolchain; a broken toolchain must fail configure
+# loudly, not ship binaries that silently lack Temporal
+major=${fullversion%%.*}
+if [ "${major#v}" -ge 26 ]; then
+  config_flags="$config_flags --v8-enable-temporal-support"
+fi
+
+# gyp emits one shared node_crates archive for host and target toolsets; one
+# archive cannot serve two architectures. Point each toolset at its own
+# triple's build (the cargo shim in the image builds both). Skipped silently
+# on versions without the rust crates (Node < 26).
+if [ -f deps/crates/crates.gyp ]; then
+  python3 - <<'GYPPATCH'
+import re
+path = 'deps/crates/crates.gyp'
+src = open(path).read()
+pattern = re.compile(
+    r"'link_settings':\s*\{\s*'libraries':\s*\[\s*'<\(node_crates_libpath\)',\s*\]", re.S)
+replacement = """'link_settings': {
+        'target_conditions': [
+          ['_toolset=="host"', {
+            'libraries': ['<(SHARED_INTERMEDIATE_DIR)/x86_64-unknown-linux-musl/release/libnode_crates.a'],
+          }],
+          ['_toolset=="target"', {
+            'libraries': ['<(SHARED_INTERMEDIATE_DIR)/aarch64-unknown-linux-musl/release/libnode_crates.a'],
+          }],
+        ]"""
+patched, count = pattern.subn(replacement, src, count=1)
+assert count == 1, 'crates.gyp link_settings pattern not found'
+open(path, 'w').write(patched)
+GYPPATCH
+fi
+
 make -j$(getconf _NPROCESSORS_ONLN) binary V= \
   DESTCPU="arm64" \
   ARCH="arm64" \


### PR DESCRIPTION
## Summary

Node 26 enables the Temporal API by default, but its build silently skips Temporal when `rustc`/`cargo` are missing from PATH. The `x64-musl` recipe was already updated in #228; this PR is the corresponding fix for `arm64-musl` that @MikeMcC399 explicitly called out as still outstanding in https://github.com/nodejs/unofficial-builds/issues/227#issuecomment-... :

> PR #228 resolved this issue for amd64. It did not address: `recipes/arm64-musl` for arm64

So today the unofficial `linux-arm64-musl` tarball ships without Temporal, which means any downstream consumer of these tarballs (currently x64-alpine via docker-node; arm64-alpine pending nodejs/docker-node#2475) is missing the feature on arm64-musl.

## Diff

```diff
 RUN apk add --no-cache \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         ...
         ccache \
         xz \
         patch \
+        # rustc/cargo are needed for the Temporal API support in Node 26+
+        # (build silently skips Temporal when they are not in PATH)
+        rust \
+        cargo \
         # extra packages required for creating the musl based cross-compiler
         rsync make gcc g++ bzip2 git
```

Same `rust + cargo` apk additions PR #228 made for `recipes/musl/Dockerfile`.

## Verification

`alpine:3.22` (the recipe's base) ships both packages:

```sh
$ docker run --rm alpine:3.22 sh -c 'apk add --no-cache rust cargo && rustc --version && cargo --version'
rustc 1.87.0 (17067e9ac 2025-05-09) (Alpine Linux 1.87.0-r1)
cargo 1.87.0 (99624be96 2025-05-06) (Alpine Linux 1.87.0-r1)
```

As with #233, I haven't been able to validate the full Node build locally (musl-cross-make toolchain build is ~30 min and Node from source is ~1–2 hr on my hardware); the change mirrors #228 exactly so the risk should be similar.

Refs: #227, #228