### PR TITLE
Use --without-ffi on riscv64

### DIFF
--- a/recipes/riscv64-pointer-compression/run.sh
+++ b/recipes/riscv64-pointer-compression/run.sh
@@ -11,7 +11,7 @@ commit="$5"
 fullversion="$6"
 source_url="$7"
 source_urlbase="$8"
-config_flags="--openssl-no-asm --use_clang --experimental-enable-pointer-compression"
+config_flags="--openssl-no-asm --use_clang --experimental-enable-pointer-compression --without-ffi"
 
 cd /home/node
 

--- a/recipes/riscv64/run.sh
+++ b/recipes/riscv64/run.sh
@@ -11,7 +11,7 @@ commit="$5"
 fullversion="$6"
 source_url="$7"
 source_urlbase="$8"
-config_flags="--openssl-no-asm"
+config_flags="--openssl-no-asm --without-ffi"
 
 cd /home/node
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/unofficial-builds/issues/235

More investigation is required to see if this can be properly enabled in some environments, and if not then it should be disabled in https://github.com/nodejs/node/blob/39b481b5c510d3a12b6eea15a17681e6773d0b5d/configure.py#L2343 but this is a tactical fix that should allow it to be released with functionality consistent with v26.1.0
