### PR TITLE
Revert "Use --without-ffi on riscv64 (#236)"

### DIFF
--- a/recipes/riscv64-pointer-compression/run.sh
+++ b/recipes/riscv64-pointer-compression/run.sh
@@ -11,7 +11,7 @@ commit="$5"
 fullversion="$6"
 source_url="$7"
 source_urlbase="$8"
-config_flags="--openssl-no-asm --use_clang --experimental-enable-pointer-compression --without-ffi"
+config_flags="--openssl-no-asm --use_clang --experimental-enable-pointer-compression"
 
 cd /home/node
 

--- a/recipes/riscv64/run.sh
+++ b/recipes/riscv64/run.sh
@@ -11,7 +11,7 @@ commit="$5"
 fullversion="$6"
 source_url="$7"
 source_urlbase="$8"
-config_flags="--openssl-no-asm --without-ffi"
+config_flags="--openssl-no-asm"
 
 cd /home/node
 


### PR DESCRIPTION
This reverts commit 27d048e38f2a5baa7702256be31042c09331eae6.

The upstream FFI change has backported into node in https://github.com/nodejs/node/pull/63794 so `libffi` can be re-enabled. 

This PR should not be merged until the that one has gone in, hence draft for now but reviews welcome. 

